### PR TITLE
(MAINT) This updates some targets in the makefile to building and check the code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,23 @@
-GOLANGCI_LINT_VERSION=v1.10.2
+GOLANGCI_LINT_VERSION=v1.37.1
 
-LINTER=./bin/golangci-lint
+ifndef GOPATH
+	GOPATH := $(shell go env GOPATH)
+endif
 
-.PHONY: build clean test lint
+# Default target will fetch deps, build and run tests.
+all: tidy generate build check test
 
 generate:
-	oapi-codegen -generate client,spec -package=rest ./api.yaml > ./pkg/rest/services.gen.go
-	oapi-codegen -generate types -package=rest ./api.yaml > ./pkg/rest/types.gen.go
+	oapi-codegen -generate client,spec -package=rest ./api.yaml > rest/services.gen.go
+	oapi-codegen -generate types -package=rest ./api.yaml > rest/types.gen.go
+
+tidy:
+	go mod tidy
 
 build:
 	go build ./...
+
+check: format lint sec
 
 clean:
 	go clean
@@ -17,8 +25,71 @@ clean:
 test:
 	go test -race -v --cover ./...
 
-$(LINTER):
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s $(GOLANGCI_LINT_VERSION)
 
-lint: $(LINTER)
-	$(LINTER) run ./...
+# Format go code and error if any changes are made
+PHONY+= format
+format:
+	@echo "Checking that go fmt does not make any changes..."
+	@test -z $$(go fmt $(go list ./...)) || (echo "go fmt would make a change. Please verify and commit the proposed changes"; exit 1)
+	@echo "Checking go fmt complete"
+
+PHONY+= lint
+lint: $(GOPATH)/bin/golangci-lint $(GOPATH)/bin/golint
+	@echo "Linting $(1)"
+	@golint -set_exit_status ./...
+	@go vet ./...
+	@golangci-lint run \
+		-E asciicheck \
+		-E bodyclose \
+		-E exhaustive \
+		-E exportloopref \
+		-E gci \
+		-E gofmt \
+		-E goimports \
+		-E goimports \
+		-E gosec \
+		-E noctx \
+		-E nolintlint \
+		-E rowserrcheck \
+		-E scopelint \
+		-E sqlclosecheck \
+		-E stylecheck \
+		-E unconvert \
+		-E unparam
+	@echo "Lint-free"
+
+#
+# Install Tools 
+#
+PHONY+= sec
+sec: $(GOPATH)/bin/gosec
+	@echo "Checking for security problems ..."
+	@gosec -quiet ./...
+	@echo "No problems found"; \
+
+$(GOPATH)/bin/golangci-lint:
+	@echo "🔘 Installing golangci-lint... (`date '+%H:%M:%S'`)"
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin
+
+$(GOPATH)/bin/golint:
+	@echo "🔘 Installing golint ... (`date '+%H:%M:%S'`)"
+	@GO111MODULE=off go get -u golang.org/x/lint/golint
+
+$(GOPATH)/bin/gosec:
+	@echo "🔘 Installing gosec ... (`date '+%H:%M:%S'`)"
+	@curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(GOPATH)/bin
+
+
+PHONY+= tools
+tools: $(GOPATH)/bin/golangci-lint $(GOPATH)/bin/golint $(GOPATH)/bin/gosec
+
+PHONY+= update-tools
+update-tools: delete-tools $(GOPATH)/bin/golangci-lint $(GOPATH)/bin/golint $(GOPATH)/bin/gosec
+
+PHONY+= delete-tools
+delete-tools:
+	@rm $(GOPATH)/bin/golangci-lint
+	@rm $(GOPATH)/bin/gosec
+	@rm $(GOPATH)/bin/golint
+
+.PHONY: all tidy generate build clean test lint

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Harness FFM Server-side SDK for Go
 
+[![Go Report Card](https://goreportcard.com/badge/github.com/drone/ff-golang-server-sdk)](https://goreportcard.com/report/github.com/drone/ff-golang-server-sdk)
+
 ## FFM overview
 FFM is feature flag management platform for helping teams to deliver better software and faster.
 

--- a/evaluation/feature_test.go
+++ b/evaluation/feature_test.go
@@ -2,8 +2,8 @@ package evaluation
 
 import (
 	"encoding/json"
-	"github.com/google/uuid"
 	"github.com/drone/ff-golang-server-sdk/types"
+	"github.com/google/uuid"
 	"reflect"
 	"strconv"
 	"testing"

--- a/evaluation/reflection_test.go
+++ b/evaluation/reflection_test.go
@@ -74,11 +74,11 @@ func Test_caseInsensitiveFieldByName(t *testing.T) {
 		{name: "check with struct", args: struct {
 			v    reflect.Value
 			name string
-		}{v:reflect.ValueOf(target), name: "identifier"}, want: reflect.ValueOf("john")},
+		}{v: reflect.ValueOf(target), name: "identifier"}, want: reflect.ValueOf("john")},
 		{name: "check with other than struct", args: struct {
 			v    reflect.Value
 			name string
-		}{v:reflect.ValueOf("Identifier"), name: "identifier"}, want: reflect.ValueOf("Identifier")},
+		}{v: reflect.ValueOf("Identifier"), name: "identifier"}, want: reflect.ValueOf("Identifier")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/r3labs/sse v0.0.0-20200629114018-c9bb0c82ec80 h1:BcutWYmIuaJkm1DK5gTTl/q6+kuT6lAEhK4TYdod1rE=
-github.com/r3labs/sse v0.0.0-20200629114018-c9bb0c82ec80/go.mod h1:S8xSOnV3CgpNrWd0GQ/OoQfMtlg2uPRSuTzcSGrzwK8=
 github.com/r3labs/sse v0.0.0-20201126193848-34e640891548 h1:ewzX4RiFeFXl8APBmMqXBXR5CZoF/jctB71BuLg7d3s=
 github.com/r3labs/sse v0.0.0-20201126193848-34e640891548/go.mod h1:S8xSOnV3CgpNrWd0GQ/OoQfMtlg2uPRSuTzcSGrzwK8=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -77,7 +75,6 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.1.0 h1:RZqt0yGBsps8NGvLSGW804QQqCUYYLsaOjTVHy1Ocw4=
 github.com/valyala/fasttemplate v1.1.0/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
-github.com/wings-software/ff-client-sdk-go v0.0.0-20210302094748-2b28d05dbab0 h1:dD9k6J670ykM+WmAcmzBKga29kMqX7tKmtZRJnOJ6i0=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
@@ -103,8 +100,6 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191112182307-2180aed22343/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191116160921-f9c825593386/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
-golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777 h1:003p0dJM77cxMSyCPFphvZf/Y5/NXf5fzg6ufd1/Oew=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -114,8 +109,6 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191115151921-52ab43148777/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
-golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/types/bool.go
+++ b/types/bool.go
@@ -7,7 +7,6 @@ import (
 
 type Boolean bool
 
-
 func NewBoolean(value interface{}) (*Boolean, error) {
 	num, ok := value.(bool)
 	if ok {
@@ -64,4 +63,3 @@ func (b Boolean) LessThanEqual(value interface{}) bool {
 func (b Boolean) In(value interface{}) bool {
 	return false
 }
-


### PR DESCRIPTION

* Added default target 'all'.    Just running ```make``` should be enough to build, check and test the code
* Use ```go env``` to determine the correct place to install binaries
* Updated the version of the linter being used
* introduced gofmt, gosec and golint checks.  These are run automatically as part of all
*  Added goreport card to README.md

Additional changes to the code are a result of running gofmt.