### PR TITLE
(MAINT) This removes the unnecessary v0 module declaration

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,7 +1,7 @@
 package cache
 
 import (
-	"github.com/drone/ff-golang-server-sdk.v0/logger"
+	"github.com/drone/ff-golang-server-sdk/logger"
 
 	"time"
 )

--- a/cache/lru.go
+++ b/cache/lru.go
@@ -1,7 +1,7 @@
 package cache
 
 import (
-	"github.com/drone/ff-golang-server-sdk.v0/logger"
+	"github.com/drone/ff-golang-server-sdk/logger"
 	lru "github.com/hashicorp/golang-lru"
 
 	"reflect"

--- a/cache/persist.go
+++ b/cache/persist.go
@@ -1,10 +1,10 @@
 package cache
 
 import (
-	"github.com/drone/ff-golang-server-sdk.v0/dto"
-	"github.com/drone/ff-golang-server-sdk.v0/evaluation"
-	"github.com/drone/ff-golang-server-sdk.v0/logger"
-	"github.com/drone/ff-golang-server-sdk.v0/storage"
+	"github.com/drone/ff-golang-server-sdk/dto"
+	"github.com/drone/ff-golang-server-sdk/evaluation"
+	"github.com/drone/ff-golang-server-sdk/logger"
+	"github.com/drone/ff-golang-server-sdk/storage"
 	"github.com/mitchellh/mapstructure"
 )
 

--- a/client/client.go
+++ b/client/client.go
@@ -12,12 +12,12 @@ import (
 
 	"github.com/deepmap/oapi-codegen/pkg/securityprovider"
 	"github.com/dgrijalva/jwt-go"
-	"github.com/drone/ff-golang-server-sdk.v0/cache"
-	"github.com/drone/ff-golang-server-sdk.v0/dto"
-	"github.com/drone/ff-golang-server-sdk.v0/evaluation"
-	"github.com/drone/ff-golang-server-sdk.v0/rest"
-	"github.com/drone/ff-golang-server-sdk.v0/stream"
-	"github.com/drone/ff-golang-server-sdk.v0/types"
+	"github.com/drone/ff-golang-server-sdk/cache"
+	"github.com/drone/ff-golang-server-sdk/dto"
+	"github.com/drone/ff-golang-server-sdk/evaluation"
+	"github.com/drone/ff-golang-server-sdk/rest"
+	"github.com/drone/ff-golang-server-sdk/stream"
+	"github.com/drone/ff-golang-server-sdk/types"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/r3labs/sse"
 )

--- a/client/config.go
+++ b/client/config.go
@@ -3,9 +3,9 @@ package client
 import (
 	"log"
 
-	"github.com/drone/ff-golang-server-sdk.v0/cache"
-	"github.com/drone/ff-golang-server-sdk.v0/logger"
-	"github.com/drone/ff-golang-server-sdk.v0/storage"
+	"github.com/drone/ff-golang-server-sdk/cache"
+	"github.com/drone/ff-golang-server-sdk/logger"
+	"github.com/drone/ff-golang-server-sdk/storage"
 )
 
 type config struct {

--- a/client/options.go
+++ b/client/options.go
@@ -1,9 +1,9 @@
 package client
 
 import (
-	"github.com/drone/ff-golang-server-sdk.v0/cache"
-	"github.com/drone/ff-golang-server-sdk.v0/logger"
-	"github.com/drone/ff-golang-server-sdk.v0/storage"
+	"github.com/drone/ff-golang-server-sdk/cache"
+	"github.com/drone/ff-golang-server-sdk/logger"
+	"github.com/drone/ff-golang-server-sdk/storage"
 )
 
 // ConfigOption is used as return value for advanced client configuration

--- a/dto/target_builder.go
+++ b/dto/target_builder.go
@@ -1,7 +1,7 @@
 package dto
 
 import (
-	"github.com/drone/ff-golang-server-sdk.v0/evaluation"
+	"github.com/drone/ff-golang-server-sdk/evaluation"
 )
 
 // TargetBuilderInterface used for fluent builder methods

--- a/evaluation/feature.go
+++ b/evaluation/feature.go
@@ -3,7 +3,7 @@ package evaluation
 import (
 	"encoding/json"
 
-	"github.com/drone/ff-golang-server-sdk.v0/types"
+	"github.com/drone/ff-golang-server-sdk/types"
 
 	"reflect"
 	"strconv"

--- a/evaluation/feature_test.go
+++ b/evaluation/feature_test.go
@@ -3,7 +3,7 @@ package evaluation
 import (
 	"encoding/json"
 
-	"github.com/drone/ff-golang-server-sdk.v0/types"
+	"github.com/drone/ff-golang-server-sdk/types"
 
 	"reflect"
 	"strconv"

--- a/evaluation/target.go
+++ b/evaluation/target.go
@@ -1,7 +1,7 @@
 package evaluation
 
 import (
-	"github.com/drone/ff-golang-server-sdk.v0/types"
+	"github.com/drone/ff-golang-server-sdk/types"
 
 	"reflect"
 )

--- a/evaluation/target_test.go
+++ b/evaluation/target_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/drone/ff-golang-server-sdk.v0/types"
+	"github.com/drone/ff-golang-server-sdk/types"
 )
 
 func TestTarget_GetOperator(t1 *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/drone/ff-golang-server-sdk.v0
+module github.com/drone/ff-golang-server-sdk
 
 go 1.14
 

--- a/rest/adapter.go
+++ b/rest/adapter.go
@@ -1,6 +1,6 @@
 package rest
 
-import "github.com/drone/ff-golang-server-sdk.v0/evaluation"
+import "github.com/drone/ff-golang-server-sdk/evaluation"
 
 func (wv WeightedVariation) convert() *evaluation.WeightedVariation {
 	return &evaluation.WeightedVariation{

--- a/storage/file.go
+++ b/storage/file.go
@@ -3,7 +3,7 @@ package storage
 import (
 	"fmt"
 
-	"github.com/drone/ff-golang-server-sdk.v0/logger"
+	"github.com/drone/ff-golang-server-sdk/logger"
 
 	jsoniter "github.com/json-iterator/go"
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -6,7 +6,7 @@ import (
 	"path"
 	"time"
 
-	"github.com/drone/ff-golang-server-sdk.v0/logger"
+	"github.com/drone/ff-golang-server-sdk/logger"
 	"github.com/mitchellh/go-homedir"
 )
 

--- a/stream/sse.go
+++ b/stream/sse.go
@@ -6,9 +6,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/drone/ff-golang-server-sdk.v0/cache"
-	"github.com/drone/ff-golang-server-sdk.v0/dto"
-	"github.com/drone/ff-golang-server-sdk.v0/rest"
+	"github.com/drone/ff-golang-server-sdk/cache"
+	"github.com/drone/ff-golang-server-sdk/dto"
+	"github.com/drone/ff-golang-server-sdk/rest"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/r3labs/sse"
 )


### PR DESCRIPTION
Why In the go.mod the module was defined as being .v0.  It is not
neccessary to version the default (v0) version of a module.  It is implictlity a v0.
The format was also wrong as it should be a /vX as opposed to .vX.

How Remove the .v0 from the go.mod file and updated all deps.