### PR TITLE
(FFM-725) Implement Pre-Req Evaluation

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2,22 +2,23 @@ package client_test
 
 import (
 	"encoding/json"
+	"net/http"
+	"os"
+	"testing"
+
 	"github.com/drone/ff-golang-server-sdk/client"
 	"github.com/drone/ff-golang-server-sdk/dto"
 	"github.com/drone/ff-golang-server-sdk/evaluation"
 	"github.com/drone/ff-golang-server-sdk/rest"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
-	"net/http"
-	"testing"
-	"os"
 )
 
 const (
 	sdkKey = "27bed8d2-2610-462b-90eb-d80fd594b623"
- 	URL = "http://localhost/api/1.0"
+	URL    = "http://localhost/api/1.0"
+	//nolint
 	AuthToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwcm9qZWN0IjoiMTA0MjM5NzYtODQ1MS00NmZjLTg2NzctYmNiZDM3MTA3M2JhIiwiZW52aXJvbm1lbnQiOiI3ZWQxMDI1ZC1hOWIxLTQxMjktYTg4Zi1lMjdlZjM2MDk4MmQiLCJwcm9qZWN0SWRlbnRpZmllciI6IiIsImVudmlyb25tZW50SWRlbnRpZmllciI6IlByZVByb2R1Y3Rpb24iLCJhY2NvdW50SUQiOiIiLCJvcmdhbml6YXRpb24iOiIwMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDAifQ.z6EYSDVWwwAY6OTc2PnjSub43R6lOSJywlEObi6PDqQ"
-
 )
 
 // TestMain runs before the other tests
@@ -61,13 +62,14 @@ func TestCfClient_BoolVariation(t *testing.T) {
 		{"Test Default True Flag when Pre-Req is True returns true", args{"TestTrueOnWithPreReqTrue", target, true}, true, false},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			flag, err := client.BoolVariation(tt.args.key, tt.args.target, tt.args.defaultValue)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("BoolVariation() error = %v, wantErr %v", err, tt.wantErr)
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			flag, err := client.BoolVariation(test.args.key, test.args.target, test.args.defaultValue)
+			if (err != nil) != test.wantErr {
+				t.Errorf("BoolVariation() error = %v, wantErr %v", err, test.wantErr)
 				return
 			}
-			assert.Equal(t, tt.want, flag, "%s didn't get expected value", tt.name)
+			assert.Equal(t, test.want, flag, "%s didn't get expected value", test.name)
 		})
 	}
 }
@@ -89,7 +91,6 @@ func TestCfClient_StringVariation(t *testing.T) {
 		args    args
 		want    string
 		wantErr bool
-
 	}{
 		{"Test Invalid Flag Name returns default value", args{"MadeUpIDontExist", target, "foo"}, "foo", false},
 		{"Test Default String Flag with when On returns A", args{"TestStringAOn", target, "foo"}, "A", false},
@@ -98,13 +99,14 @@ func TestCfClient_StringVariation(t *testing.T) {
 		{"Test Default String Flag when Pre-Req is True returns A", args{"TestStringAOnWithPreReqTrue", target, "foo"}, "A", false},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			flag, err := client.StringVariation(tt.args.key, tt.args.target, tt.args.defaultValue)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("BoolVariation() error = %v, wantErr %v", err, tt.wantErr)
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			flag, err := client.StringVariation(test.args.key, test.args.target, test.args.defaultValue)
+			if (err != nil) != test.wantErr {
+				t.Errorf("BoolVariation() error = %v, wantErr %v", err, test.wantErr)
 				return
 			}
-			assert.Equal(t, tt.want, flag, "%s didn't get expected value", tt.name)
+			assert.Equal(t, test.want, flag, "%s didn't get expected value", test.name)
 		})
 	}
 }
@@ -125,7 +127,6 @@ func MakeNewClientAndTarget() (*client.CfClient, *evaluation.Target, error) {
 
 	return client, target, nil
 }
-
 
 // newClient creates a new client with some default options
 func newClient(httpClient *http.Client) (*client.CfClient, error) {
@@ -149,7 +150,7 @@ func target() *evaluation.Target {
 
 var ValidAuthResponse = func(req *http.Request) (*http.Response, error) {
 	return httpmock.NewJsonResponse(200, rest.AuthenticationResponse{
-		AuthToken: 	AuthToken})
+		AuthToken: AuthToken})
 }
 
 var TargetSegmentsResponse = func(req *http.Request) (*http.Response, error) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,200 @@
+package client_test
+
+import (
+	"encoding/json"
+	"github.com/drone/ff-golang-server-sdk/client"
+	"github.com/drone/ff-golang-server-sdk/dto"
+	"github.com/drone/ff-golang-server-sdk/evaluation"
+	"github.com/drone/ff-golang-server-sdk/rest"
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+	"os"
+)
+
+const (
+	sdkKey = "27bed8d2-2610-462b-90eb-d80fd594b623"
+ 	URL = "http://localhost/api/1.0"
+	AuthToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwcm9qZWN0IjoiMTA0MjM5NzYtODQ1MS00NmZjLTg2NzctYmNiZDM3MTA3M2JhIiwiZW52aXJvbm1lbnQiOiI3ZWQxMDI1ZC1hOWIxLTQxMjktYTg4Zi1lMjdlZjM2MDk4MmQiLCJwcm9qZWN0SWRlbnRpZmllciI6IiIsImVudmlyb25tZW50SWRlbnRpZmllciI6IlByZVByb2R1Y3Rpb24iLCJhY2NvdW50SUQiOiIiLCJvcmdhbml6YXRpb24iOiIwMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDAifQ.z6EYSDVWwwAY6OTc2PnjSub43R6lOSJywlEObi6PDqQ"
+
+)
+
+// TestMain runs before the other tests
+func TestMain(m *testing.M) {
+	// httpMock overwrites the http.DefaultClient
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	// Register Default Responders
+	httpmock.RegisterResponder("POST", "http://localhost/api/1.0/client/auth", ValidAuthResponse)
+	httpmock.RegisterResponder("GET", "http://localhost/api/1.0/client/env/7ed1025d-a9b1-4129-a88f-e27ef360982d/target-segments", TargetSegmentsResponse)
+	httpmock.RegisterResponder("GET", "http://localhost/api/1.0/client/env/7ed1025d-a9b1-4129-a88f-e27ef360982d/feature-configs", FeatureConfigsResponse)
+
+	os.Exit(m.Run())
+}
+
+func TestCfClient_BoolVariation(t *testing.T) {
+
+	client, target, err := MakeNewClientAndTarget()
+	if err != nil {
+		t.Error(err)
+	}
+
+	type args struct {
+		key          string
+		target       *evaluation.Target
+		defaultValue bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{"Test Invalid Flag Name returns default value", args{"MadeUpIDontExist", target, false}, false, false},
+		{"Test Default True Flag when On returns true", args{"TestTrueOn", target, false}, true, false},
+		{"Test Default True Flag when Off returns false", args{"TestTrueOff", target, true}, false, false},
+		{"Test Default False Flag when On returns false", args{"TestTrueOn", target, false}, true, false},
+		{"Test Default False Flag when Off returns true", args{"TestTrueOff", target, true}, false, false},
+		{"Test Default True Flag when Pre-Req is False returns false", args{"TestTrueOnWithPreReqFalse", target, true}, false, false},
+		{"Test Default True Flag when Pre-Req is True returns true", args{"TestTrueOnWithPreReqTrue", target, true}, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flag, err := client.BoolVariation(tt.args.key, tt.args.target, tt.args.defaultValue)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("BoolVariation() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equal(t, tt.want, flag, "%s didn't get expected value", tt.name)
+		})
+	}
+}
+
+func TestCfClient_StringVariation(t *testing.T) {
+
+	client, target, err := MakeNewClientAndTarget()
+	if err != nil {
+		t.Error(err)
+	}
+
+	type args struct {
+		key          string
+		target       *evaluation.Target
+		defaultValue string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+
+	}{
+		{"Test Invalid Flag Name returns default value", args{"MadeUpIDontExist", target, "foo"}, "foo", false},
+		{"Test Default String Flag with when On returns A", args{"TestStringAOn", target, "foo"}, "A", false},
+		{"Test Default String Flag when Off returns B", args{"TestStringAOff", target, "foo"}, "B", false},
+		{"Test Default String Flag when Pre-Req is False returns B", args{"TestStringAOnWithPreReqFalse", target, "foo"}, "B", false},
+		{"Test Default String Flag when Pre-Req is True returns A", args{"TestStringAOnWithPreReqTrue", target, "foo"}, "A", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flag, err := client.StringVariation(tt.args.key, tt.args.target, tt.args.defaultValue)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("BoolVariation() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equal(t, tt.want, flag, "%s didn't get expected value", tt.name)
+		})
+	}
+}
+
+// MakeNewClientAndTarget creates a new client and target.  If it returns
+// error then something went wrong.
+func MakeNewClientAndTarget() (*client.CfClient, *evaluation.Target, error) {
+	target := target()
+	client, err := newClient(http.DefaultClient)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Wait to be authenticated - we can timeout if the channel doesn't return
+	if ok, err := client.IsInitialized(); !ok {
+		return nil, nil, err
+	}
+
+	return client, target, nil
+}
+
+
+// newClient creates a new client with some default options
+func newClient(httpClient *http.Client) (*client.CfClient, error) {
+	return client.NewCfClient(sdkKey,
+		client.WithURL(URL),
+		client.WithStreamEnabled(false),
+		client.WithHTTPClient(httpClient),
+		client.WithStoreEnabled(false),
+	)
+}
+
+// target creates a new Target with some default values
+func target() *evaluation.Target {
+	target := dto.NewTargetBuilder("john").
+		Firstname("John").
+		Lastname("Doe").
+		Email("john@doe.com").
+		Build()
+	return target
+}
+
+var ValidAuthResponse = func(req *http.Request) (*http.Response, error) {
+	return httpmock.NewJsonResponse(200, rest.AuthenticationResponse{
+		AuthToken: 	AuthToken})
+}
+
+var TargetSegmentsResponse = func(req *http.Request) (*http.Response, error) {
+	var AllSegmentsResponse []rest.Segment
+
+	err := json.Unmarshal([]byte(`[
+		{
+			"environment": "PreProduction",
+			"excluded": [],
+			"identifier": "Beta_Users",
+			"included": [
+				{
+					"identifier": "john",
+					"name": "John",
+				},
+				{
+					"identifier": "paul",
+					"name": "Paul",
+				}
+			],
+			"name": "Beta Users"
+		}
+	]`), &AllSegmentsResponse)
+	if err != nil {
+		return jsonError(err)
+	}
+	return httpmock.NewJsonResponse(200, AllSegmentsResponse)
+}
+
+var FeatureConfigsResponse = func(req *http.Request) (*http.Response, error) {
+	var FeatureConfigResponse []rest.FeatureConfig
+	FeatureConfigResponse = append(FeatureConfigResponse, MakeBoolFeatureConfigs("TestTrueOn", "true", "false", "on")...)
+	FeatureConfigResponse = append(FeatureConfigResponse, MakeBoolFeatureConfigs("TestTrueOff", "true", "false", "off")...)
+
+	FeatureConfigResponse = append(FeatureConfigResponse, MakeBoolFeatureConfigs("TestFalseOn", "false", "true", "on")...)
+	FeatureConfigResponse = append(FeatureConfigResponse, MakeBoolFeatureConfigs("TestFalseOff", "false", "true", "off")...)
+
+	FeatureConfigResponse = append(FeatureConfigResponse, MakeBoolFeatureConfigs("TestTrueOnWithPreReqFalse", "true", "false", "on", MakeBoolPreRequisite("PreReq1", "false"))...)
+	FeatureConfigResponse = append(FeatureConfigResponse, MakeBoolFeatureConfigs("TestTrueOnWithPreReqTrue", "true", "false", "on", MakeBoolPreRequisite("PreReq1", "true"))...)
+
+	FeatureConfigResponse = append(FeatureConfigResponse, MakeStringFeatureConfigs("TestStringAOn", "Alpha", "Bravo", "on")...)
+	FeatureConfigResponse = append(FeatureConfigResponse, MakeStringFeatureConfigs("TestStringAOff", "Alpha", "Bravo", "off")...)
+
+	FeatureConfigResponse = append(FeatureConfigResponse, MakeStringFeatureConfigs("TestStringAOnWithPreReqFalse", "Alpha", "Bravo", "on", MakeBoolPreRequisite("PreReq1", "false"))...)
+	FeatureConfigResponse = append(FeatureConfigResponse, MakeStringFeatureConfigs("TestStringAOnWithPreReqTrue", "Alpha", "Bravo", "on", MakeBoolPreRequisite("PreReq1", "true"))...)
+
+	return httpmock.NewJsonResponse(200, FeatureConfigResponse)
+}

--- a/client/config.go
+++ b/client/config.go
@@ -16,9 +16,9 @@ type config struct {
 	Cache        cache.Cache
 	Store        storage.Storage
 	Logger       logger.Logger
-	httpClient	 *http.Client
+	httpClient   *http.Client
 	enableStream bool
-	enableStore bool
+	enableStore  bool
 }
 
 func newDefaultConfig() *config {
@@ -28,7 +28,6 @@ func newDefaultConfig() *config {
 	}
 	defaultCache, _ := cache.NewLruCache(10000, defaultLogger) // size of cache
 	defaultStore := storage.NewFileStore("defaultProject", storage.GetHarnessDir(), defaultLogger)
-
 
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = 10
@@ -41,6 +40,6 @@ func newDefaultConfig() *config {
 		Logger:       defaultLogger,
 		httpClient:   retryClient.StandardClient(),
 		enableStream: true,
-		enableStore: true,
+		enableStore:  true,
 	}
 }

--- a/client/config.go
+++ b/client/config.go
@@ -2,10 +2,12 @@ package client
 
 import (
 	"log"
+	"net/http"
 
 	"github.com/drone/ff-golang-server-sdk/cache"
 	"github.com/drone/ff-golang-server-sdk/logger"
 	"github.com/drone/ff-golang-server-sdk/storage"
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 type config struct {
@@ -14,7 +16,9 @@ type config struct {
 	Cache        cache.Cache
 	Store        storage.Storage
 	Logger       logger.Logger
+	httpClient	 *http.Client
 	enableStream bool
+	enableStore bool
 }
 
 func newDefaultConfig() *config {
@@ -25,12 +29,18 @@ func newDefaultConfig() *config {
 	defaultCache, _ := cache.NewLruCache(10000, defaultLogger) // size of cache
 	defaultStore := storage.NewFileStore("defaultProject", storage.GetHarnessDir(), defaultLogger)
 
+
+	retryClient := retryablehttp.NewClient()
+	retryClient.RetryMax = 10
+
 	return &config{
 		url:          "http://localhost:7999/api/1.0",
 		pullInterval: 1,
 		Cache:        defaultCache,
 		Store:        defaultStore,
 		Logger:       defaultLogger,
+		httpClient:   retryClient.StandardClient(),
 		enableStream: true,
+		enableStore: true,
 	}
 }

--- a/client/helpers_test.go
+++ b/client/helpers_test.go
@@ -2,9 +2,10 @@ package client_test
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/drone/ff-golang-server-sdk/rest"
 	"github.com/jarcoal/httpmock"
-	"net/http"
 )
 
 func MakeBoolFeatureConfigs(name, defaultVariation, offVariation, state string, preReqs ...rest.Prerequisite) []rest.FeatureConfig {
@@ -12,7 +13,7 @@ func MakeBoolFeatureConfigs(name, defaultVariation, offVariation, state string, 
 	featureConfig = append(featureConfig, MakeBoolFeatureConfig(name, defaultVariation, offVariation, state, preReqs))
 
 	// If there are any PreReqs then we need to store them as flags as well.
-	for _, x := range preReqs{
+	for _, x := range preReqs {
 		featureConfig = append(featureConfig, MakeBoolFeatureConfig(x.Feature, "true", "false", x.Variations[0], nil))
 	}
 
@@ -24,24 +25,24 @@ func MakeBoolFeatureConfig(name, defaultVariation, offVariation, state string, p
 		DefaultServe: rest.Serve{
 			Variation: &defaultVariation,
 		},
-		Environment: "PreProduction",
-		Feature: name,
-		Kind: "boolean",
+		Environment:  "PreProduction",
+		Feature:      name,
+		Kind:         "boolean",
 		OffVariation: offVariation,
-		State: rest.FeatureState(state),
+		State:        rest.FeatureState(state),
 		Variations: []rest.Variation{
 			{Identifier: "true", Name: strPtr("True"), Value: "true"},
 			{Identifier: "false", Name: strPtr("False"), Value: "false"},
 		},
 		Prerequisites: &preReqs,
-		Version: intPtr(1),
+		Version:       intPtr(1),
 	}
 }
 
 func MakeBoolPreRequisite(name string, state string) rest.Prerequisite {
 	return rest.Prerequisite{
-			Feature: name,
-			Variations: []string{state},
+		Feature:    name,
+		Variations: []string{state},
 	}
 }
 
@@ -50,13 +51,12 @@ func MakeStringFeatureConfigs(name, defaultVariation, offVariation, state string
 	featureConfig = append(featureConfig, MakeStringFeatureConfig(name, defaultVariation, offVariation, state, preReqs))
 
 	// If there are any PreReqs then we need to store them as flags as well.
-	for _, x := range preReqs{
+	for _, x := range preReqs {
 		featureConfig = append(featureConfig, MakeBoolFeatureConfig(x.Feature, "true", "false", x.Variations[0], nil))
 	}
 
 	return featureConfig
 }
-
 
 /*
 {
@@ -85,24 +85,24 @@ func MakeStringFeatureConfigs(name, defaultVariation, offVariation, state string
 		],
 		"version": 1
 	}
- */
+*/
 
 func MakeStringFeatureConfig(name, defaultVariation, offVariation, state string, preReqs []rest.Prerequisite) rest.FeatureConfig {
 	return rest.FeatureConfig{
 		DefaultServe: rest.Serve{
 			Variation: &defaultVariation,
 		},
-		Environment: "PreProduction",
-		Feature: name,
-		Kind: "string",
+		Environment:  "PreProduction",
+		Feature:      name,
+		Kind:         "string",
 		OffVariation: offVariation,
-		State: rest.FeatureState(state),
+		State:        rest.FeatureState(state),
 		Variations: []rest.Variation{
 			{Identifier: "Alpha", Name: strPtr("Alpha"), Value: "A"},
 			{Identifier: "Bravo", Name: strPtr("Bravo"), Value: "B"},
 		},
 		Prerequisites: &preReqs,
-		Version: intPtr(1),
+		Version:       intPtr(1),
 	}
 }
 
@@ -114,6 +114,6 @@ func strPtr(value string) *string {
 	return &value
 }
 
-func jsonError(err error)  (*http.Response, error) {
+func jsonError(err error) (*http.Response, error) {
 	return httpmock.NewJsonResponse(500, fmt.Errorf(`{"error" : "%s"}`, err))
 }

--- a/client/helpers_test.go
+++ b/client/helpers_test.go
@@ -1,0 +1,119 @@
+package client_test
+
+import (
+	"fmt"
+	"github.com/drone/ff-golang-server-sdk/rest"
+	"github.com/jarcoal/httpmock"
+	"net/http"
+)
+
+func MakeBoolFeatureConfigs(name, defaultVariation, offVariation, state string, preReqs ...rest.Prerequisite) []rest.FeatureConfig {
+	var featureConfig []rest.FeatureConfig
+	featureConfig = append(featureConfig, MakeBoolFeatureConfig(name, defaultVariation, offVariation, state, preReqs))
+
+	// If there are any PreReqs then we need to store them as flags as well.
+	for _, x := range preReqs{
+		featureConfig = append(featureConfig, MakeBoolFeatureConfig(x.Feature, "true", "false", x.Variations[0], nil))
+	}
+
+	return featureConfig
+}
+
+func MakeBoolFeatureConfig(name, defaultVariation, offVariation, state string, preReqs []rest.Prerequisite) rest.FeatureConfig {
+	return rest.FeatureConfig{
+		DefaultServe: rest.Serve{
+			Variation: &defaultVariation,
+		},
+		Environment: "PreProduction",
+		Feature: name,
+		Kind: "boolean",
+		OffVariation: offVariation,
+		State: rest.FeatureState(state),
+		Variations: []rest.Variation{
+			{Identifier: "true", Name: strPtr("True"), Value: "true"},
+			{Identifier: "false", Name: strPtr("False"), Value: "false"},
+		},
+		Prerequisites: &preReqs,
+		Version: intPtr(1),
+	}
+}
+
+func MakeBoolPreRequisite(name string, state string) rest.Prerequisite {
+	return rest.Prerequisite{
+			Feature: name,
+			Variations: []string{state},
+	}
+}
+
+func MakeStringFeatureConfigs(name, defaultVariation, offVariation, state string, preReqs ...rest.Prerequisite) []rest.FeatureConfig {
+	var featureConfig []rest.FeatureConfig
+	featureConfig = append(featureConfig, MakeStringFeatureConfig(name, defaultVariation, offVariation, state, preReqs))
+
+	// If there are any PreReqs then we need to store them as flags as well.
+	for _, x := range preReqs{
+		featureConfig = append(featureConfig, MakeBoolFeatureConfig(x.Feature, "true", "false", x.Variations[0], nil))
+	}
+
+	return featureConfig
+}
+
+
+/*
+{
+		"defaultServe": {
+			"variation": "Alpha"
+		},
+		"environment": "PreProduction",
+		"feature": "TestStringFlag",
+		"kind": "string",
+		"offVariation": "Bravo",
+		"prerequisites": [],
+		"project": "Customer_Self_Service_Portal",
+		"rules": [],
+		"state": "off",
+		"variations": [
+			{
+				"identifier": "Alpha",
+				"name": "Bravo",
+				"value": "A"
+			},
+			{
+				"identifier": "Bravo",
+				"name": "Bravo",
+				"value": "B"
+			}
+		],
+		"version": 1
+	}
+ */
+
+func MakeStringFeatureConfig(name, defaultVariation, offVariation, state string, preReqs []rest.Prerequisite) rest.FeatureConfig {
+	return rest.FeatureConfig{
+		DefaultServe: rest.Serve{
+			Variation: &defaultVariation,
+		},
+		Environment: "PreProduction",
+		Feature: name,
+		Kind: "string",
+		OffVariation: offVariation,
+		State: rest.FeatureState(state),
+		Variations: []rest.Variation{
+			{Identifier: "Alpha", Name: strPtr("Alpha"), Value: "A"},
+			{Identifier: "Bravo", Name: strPtr("Bravo"), Value: "B"},
+		},
+		Prerequisites: &preReqs,
+		Version: intPtr(1),
+	}
+}
+
+func intPtr(value int64) *int64 {
+	return &value
+}
+
+func strPtr(value string) *string {
+	return &value
+}
+
+func jsonError(err error)  (*http.Response, error) {
+	return httpmock.NewJsonResponse(500, fmt.Errorf(`{"error" : "%s"}`, err))
+}

--- a/client/options.go
+++ b/client/options.go
@@ -1,10 +1,11 @@
 package client
 
 import (
+	"net/http"
+
 	"github.com/drone/ff-golang-server-sdk/cache"
 	"github.com/drone/ff-golang-server-sdk/logger"
 	"github.com/drone/ff-golang-server-sdk/storage"
-	"net/http"
 )
 
 // ConfigOption is used as return value for advanced client configuration
@@ -65,7 +66,6 @@ func WithStoreEnabled(val bool) ConfigOption {
 		config.enableStore = val
 	}
 }
-
 
 // WithHTTPClient set http client for use in interactions with ff server
 func WithHTTPClient(client *http.Client) ConfigOption {

--- a/client/options.go
+++ b/client/options.go
@@ -4,6 +4,7 @@ import (
 	"github.com/drone/ff-golang-server-sdk/cache"
 	"github.com/drone/ff-golang-server-sdk/logger"
 	"github.com/drone/ff-golang-server-sdk/storage"
+	"net/http"
 )
 
 // ConfigOption is used as return value for advanced client configuration
@@ -55,5 +56,20 @@ func WithLogger(logger logger.Logger) ConfigOption {
 func WithStreamEnabled(val bool) ConfigOption {
 	return func(config *config) {
 		config.enableStream = val
+	}
+}
+
+// WithStoreEnabled set store on or off
+func WithStoreEnabled(val bool) ConfigOption {
+	return func(config *config) {
+		config.enableStore = val
+	}
+}
+
+
+// WithHTTPClient set http client for use in interactions with ff server
+func WithHTTPClient(client *http.Client) ConfigOption {
+	return func(config *config) {
+		config.httpClient = client
 	}
 }

--- a/evaluation/feature.go
+++ b/evaluation/feature.go
@@ -2,7 +2,6 @@ package evaluation
 
 import (
 	"encoding/json"
-
 	"github.com/drone/ff-golang-server-sdk/types"
 
 	"reflect"

--- a/evaluation/feature.go
+++ b/evaluation/feature.go
@@ -2,6 +2,7 @@ package evaluation
 
 import (
 	"encoding/json"
+
 	"github.com/drone/ff-golang-server-sdk/types"
 
 	"reflect"

--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,14 @@ require (
 	github.com/google/uuid v1.2.0
 	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/hashicorp/golang-lru v0.5.4
+	github.com/jarcoal/httpmock v1.0.8
 	github.com/json-iterator/go v1.1.10
+	github.com/labstack/gommon v0.3.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/r3labs/sse v0.0.0-20201126193848-34e640891548
 	github.com/spaolacci/murmur3 v1.1.0
+	github.com/stretchr/testify v1.5.1
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/hashicorp/go-retryablehttp v0.6.8 h1:92lWxgpa+fF3FozM4B3UZtHZMJX8T5XT
 github.com/hashicorp/go-retryablehttp v0.6.8/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/jarcoal/httpmock v1.0.8 h1:8kI16SoO6LQKgPE7PvQuV+YuD/inwHd7fOOe2zMbo4k=
+github.com/jarcoal/httpmock v1.0.8/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=


### PR DESCRIPTION
If a flag has pre-requisistes then they should be evaluated before returning the
flag.  If a pre-req is not met, then we return the offVariation for the flag.

In order to make this more testable, the persistence store can be disabled, and the http client used in API requests can be overwritten.