### PR TITLE
(FFM-767) Return variation rather than value

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -375,7 +375,11 @@ func (c *CfClient) BoolVariation(key string, target *evaluation.Target, defaultV
 		if !result {
 			return fc.Variations.FindByIdentifier(fc.OffVariation).Bool(defaultValue), nil
 		}
-		return fc.BoolVariation(target, defaultValue), nil
+		variation, err := fc.BoolVariation(target)
+		if err != nil {
+			return defaultValue, err
+		}
+		return variation.Bool(defaultValue), nil
 	}
 	return defaultValue, nil
 }
@@ -393,7 +397,12 @@ func (c *CfClient) StringVariation(key string, target *evaluation.Target, defaul
 		if !result {
 			return fc.Variations.FindByIdentifier(fc.OffVariation).String(defaultValue), nil
 		}
-		return fc.StringVariation(target, defaultValue), nil
+		variation, err := fc.StringVariation(target)
+		if err != nil {
+			return defaultValue, err
+		}
+
+		return variation.String(defaultValue), nil
 	}
 	return defaultValue, nil
 }
@@ -411,7 +420,12 @@ func (c *CfClient) IntVariation(key string, target *evaluation.Target, defaultVa
 		if !result {
 			return fc.Variations.FindByIdentifier(fc.OffVariation).Int(defaultValue), nil
 		}
-		return fc.IntVariation(target, defaultValue), nil
+		variation, err :=  fc.IntVariation(target)
+		if err != nil {
+			return defaultValue, err
+		}
+
+		return variation.Int(defaultValue), nil
 	}
 	return defaultValue, nil
 }
@@ -429,7 +443,12 @@ func (c *CfClient) NumberVariation(key string, target *evaluation.Target, defaul
 		if !result {
 			return fc.Variations.FindByIdentifier(fc.OffVariation).Number(defaultValue), nil
 		}
-		return fc.NumberVariation(target, defaultValue), nil
+		variation, err := fc.NumberVariation(target)
+		if err != nil {
+			return defaultValue, err
+		}
+
+		return variation.Number(defaultValue), nil
 	}
 	return defaultValue, nil
 }
@@ -448,7 +467,12 @@ func (c *CfClient) JSONVariation(key string, target *evaluation.Target, defaultV
 		if !result {
 			return fc.Variations.FindByIdentifier(fc.OffVariation).JSON(defaultValue), nil
 		}
-		return fc.JSONVariation(target, defaultValue), nil
+		variation, err := fc.JSONVariation(target)
+		if err != nil {
+			return defaultValue, err
+		}
+
+		return variation.JSON(defaultValue), err
 	}
 	return defaultValue, nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -420,7 +420,7 @@ func (c *CfClient) IntVariation(key string, target *evaluation.Target, defaultVa
 		if !result {
 			return fc.Variations.FindByIdentifier(fc.OffVariation).Int(defaultValue), nil
 		}
-		variation, err :=  fc.IntVariation(target)
+		variation, err := fc.IntVariation(target)
 		if err != nil {
 			return defaultValue, err
 		}

--- a/evaluation/feature.go
+++ b/evaluation/feature.go
@@ -2,6 +2,7 @@ package evaluation
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/drone/ff-golang-server-sdk/types"
 
@@ -20,11 +21,16 @@ const (
 	equalSensitiveOperator = "equal_sensitive"
 )
 
+var (
+	unexpectedType = fmt.Errorf("unexpected type")
+	nillTarget = fmt.Errorf("unable to get variation - target is null")
+)
+
 // Evaluation object is in most cases returned value from evaluation
 // methods and contains results of evaluated feature flag for target object
 type Evaluation struct {
 	Flag  string
-	Value interface{}
+	Variation Variation
 }
 
 // Clause object
@@ -164,30 +170,31 @@ func (fc *FeatureConfig) GetKind() reflect.Kind {
 }
 
 // Evaluate feature flag and return Evaluation object
-func (fc FeatureConfig) Evaluate(target *Target) *Evaluation {
-	var value interface{}
+func (fc FeatureConfig) Evaluate(target *Target) (Evaluation, error) {
+	var variation Variation
+	var err error
+
 	switch fc.GetKind() {
 	case reflect.Bool:
-		value = fc.BoolVariation(target, false) // need more info
+		variation, err = fc.BoolVariation(target) // need more info
 	case reflect.String:
-		value = fc.StringVariation(target, "") // need more info
+		variation, err = fc.StringVariation(target) // need more info
 	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int8, reflect.Uint, reflect.Uint16,
 		reflect.Uint32, reflect.Uint64, reflect.Uint8:
-		value = fc.IntVariation(target, 0)
+		variation, err = fc.IntVariation(target)
 	case reflect.Float64, reflect.Float32:
-		value = fc.NumberVariation(target, 0)
+		variation, err = fc.NumberVariation(target)
 	case reflect.Map:
-		value = fc.JSONVariation(target, map[string]interface{}{})
+		variation, err = fc.JSONVariation(target)
 	case reflect.Array, reflect.Chan, reflect.Complex128, reflect.Complex64, reflect.Func, reflect.Interface,
 		reflect.Invalid, reflect.Ptr, reflect.Slice, reflect.Struct, reflect.Uintptr, reflect.UnsafePointer:
-		return nil
-	default:
-		value = nil
+		err = fmt.Errorf("unexpected type: %s for flag %s", fc.GetKind().String(), fc.Feature)
 	}
-	return &Evaluation{
+
+	return Evaluation{
 		Flag:  fc.Feature,
-		Value: value,
-	}
+		Variation: variation,
+	}, err
 }
 
 // GetVariationName returns variation identifier for target
@@ -212,44 +219,57 @@ func (fc FeatureConfig) GetVariationName(target *Target) string {
 
 }
 
-// BoolVariation returns boolean evaluation for target
-func (fc *FeatureConfig) BoolVariation(target *Target, defaultValue bool) bool {
-	if fc.GetKind() != reflect.Bool {
-		return defaultValue
+func getVariation(fc FeatureConfig, target *Target) (Variation, error) {
+	variation := fc.Variations.FindByIdentifier(fc.GetVariationName(target))
+	if variation == nil {
+		var targetID string
+		if target != nil {
+			targetID = target.Identifier
+		}
+
+		return Variation{}, fmt.Errorf("unable to get variation for feature %s and target %s", fc.Feature, targetID)
 	}
-	return fc.Variations.FindByIdentifier(fc.GetVariationName(target)).Bool(defaultValue)
+	return *variation, nil
+}
+
+// BoolVariation returns boolean evaluation for target
+func (fc *FeatureConfig) BoolVariation(target *Target) (Variation, error) {
+	if fc.GetKind() != reflect.Bool {
+		return Variation{}, unexpectedType
+	}
+	return getVariation(*fc, target)
 }
 
 // StringVariation returns string evaluation for target
-func (fc *FeatureConfig) StringVariation(target *Target, defaultValue string) string {
+func (fc *FeatureConfig) StringVariation(target *Target) (Variation, error) {
 	if fc.GetKind() != reflect.String {
-		return defaultValue
+		return Variation{}, unexpectedType
 	}
-	return fc.Variations.FindByIdentifier(fc.GetVariationName(target)).String(defaultValue)
+	return getVariation(*fc, target)
 }
 
 // IntVariation returns int evaluation for target
-func (fc *FeatureConfig) IntVariation(target *Target, defaultValue int64) int64 {
+func (fc *FeatureConfig) IntVariation(target *Target) (Variation, error) {
 	if fc.GetKind() != reflect.Int {
-		return defaultValue
+		return Variation{}, unexpectedType
 	}
-	return fc.Variations.FindByIdentifier(fc.GetVariationName(target)).Int(defaultValue)
+	return getVariation(*fc, target)
 }
 
 // NumberVariation returns number evaluation for target
-func (fc *FeatureConfig) NumberVariation(target *Target, defaultValue float64) float64 {
+func (fc *FeatureConfig) NumberVariation(target *Target) (Variation, error) {
 	if fc.GetKind() != reflect.Float64 {
-		return defaultValue
+		return Variation{}, unexpectedType
 	}
-	return fc.Variations.FindByIdentifier(fc.GetVariationName(target)).Number(defaultValue)
+	return getVariation(*fc, target)
 }
 
 // JSONVariation returns json evaluation for target
-func (fc *FeatureConfig) JSONVariation(target *Target, defaultValue types.JSON) types.JSON {
+func (fc *FeatureConfig) JSONVariation(target *Target) (Variation, error) {
 	if fc.GetKind() != reflect.Map {
-		return defaultValue
+		return Variation{}, unexpectedType
 	}
-	return fc.Variations.FindByIdentifier(fc.GetVariationName(target)).JSON(defaultValue)
+	return getVariation(*fc, target)
 }
 
 // FeatureState represents feature flag ON or OFF state

--- a/evaluation/feature.go
+++ b/evaluation/feature.go
@@ -22,14 +22,13 @@ const (
 )
 
 var (
-	unexpectedType = fmt.Errorf("unexpected type")
-	nillTarget = fmt.Errorf("unable to get variation - target is null")
+	errUnexpectedType = fmt.Errorf("unexpected type")
 )
 
 // Evaluation object is in most cases returned value from evaluation
 // methods and contains results of evaluated feature flag for target object
 type Evaluation struct {
-	Flag  string
+	Flag      string
 	Variation Variation
 }
 
@@ -192,7 +191,7 @@ func (fc FeatureConfig) Evaluate(target *Target) (Evaluation, error) {
 	}
 
 	return Evaluation{
-		Flag:  fc.Feature,
+		Flag:      fc.Feature,
 		Variation: variation,
 	}, err
 }
@@ -235,7 +234,7 @@ func getVariation(fc FeatureConfig, target *Target) (Variation, error) {
 // BoolVariation returns boolean evaluation for target
 func (fc *FeatureConfig) BoolVariation(target *Target) (Variation, error) {
 	if fc.GetKind() != reflect.Bool {
-		return Variation{}, unexpectedType
+		return Variation{}, errUnexpectedType
 	}
 	return getVariation(*fc, target)
 }
@@ -243,7 +242,7 @@ func (fc *FeatureConfig) BoolVariation(target *Target) (Variation, error) {
 // StringVariation returns string evaluation for target
 func (fc *FeatureConfig) StringVariation(target *Target) (Variation, error) {
 	if fc.GetKind() != reflect.String {
-		return Variation{}, unexpectedType
+		return Variation{}, errUnexpectedType
 	}
 	return getVariation(*fc, target)
 }
@@ -251,7 +250,7 @@ func (fc *FeatureConfig) StringVariation(target *Target) (Variation, error) {
 // IntVariation returns int evaluation for target
 func (fc *FeatureConfig) IntVariation(target *Target) (Variation, error) {
 	if fc.GetKind() != reflect.Int {
-		return Variation{}, unexpectedType
+		return Variation{}, errUnexpectedType
 	}
 	return getVariation(*fc, target)
 }
@@ -259,7 +258,7 @@ func (fc *FeatureConfig) IntVariation(target *Target) (Variation, error) {
 // NumberVariation returns number evaluation for target
 func (fc *FeatureConfig) NumberVariation(target *Target) (Variation, error) {
 	if fc.GetKind() != reflect.Float64 {
-		return Variation{}, unexpectedType
+		return Variation{}, errUnexpectedType
 	}
 	return getVariation(*fc, target)
 }
@@ -267,7 +266,7 @@ func (fc *FeatureConfig) NumberVariation(target *Target) (Variation, error) {
 // JSONVariation returns json evaluation for target
 func (fc *FeatureConfig) JSONVariation(target *Target) (Variation, error) {
 	if fc.GetKind() != reflect.Map {
-		return Variation{}, unexpectedType
+		return Variation{}, errUnexpectedType
 	}
 	return getVariation(*fc, target)
 }

--- a/evaluation/feature_test.go
+++ b/evaluation/feature_test.go
@@ -2,6 +2,7 @@ package evaluation
 
 import (
 	"encoding/json"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/drone/ff-golang-server-sdk/types"
@@ -13,15 +14,14 @@ import (
 )
 
 const (
-	boolKind = "boolean"
+	boolKind   = "boolean"
 	stringKind = "string"
 	numberKind = "number"
-	intKind = "int"
-	jsonKind = "json"
+	intKind    = "int"
+	jsonKind   = "json"
 )
 
 func TestFeatureConfig_JsonVariation(t *testing.T) {
-
 
 	v1Value, err := json.Marshal(map[string]interface{}{
 		"name":    "sdk",
@@ -30,8 +30,6 @@ func TestFeatureConfig_JsonVariation(t *testing.T) {
 	if err != nil {
 		t.Fail()
 	}
-
-
 
 	v2Value, err := json.Marshal(map[string]interface{}{
 		"name":    "sdk",
@@ -44,46 +42,46 @@ func TestFeatureConfig_JsonVariation(t *testing.T) {
 	jsonflagName := "SimpleJSON"
 
 	on := Variation{
-		Name: stringPtr("On"),
-		Value: string(v1Value),
+		Name:       stringPtr("On"),
+		Value:      string(v1Value),
 		Identifier: "on",
 	}
 
 	off := Variation{
-		Name: stringPtr("Off"),
-		Value: string(v2Value),
+		Name:       stringPtr("Off"),
+		Value:      string(v2Value),
 		Identifier: "off",
 	}
 
 	other := Variation{
-		Name: stringPtr("Other"),
-		Value: "",
+		Name:       stringPtr("Other"),
+		Value:      "",
 		Identifier: "other",
 	}
 
 	tests := []struct {
-		name   string
+		name          string
 		featureConfig FeatureConfig
-		want   Variation
-		wantErr bool
+		want          Variation
+		wantErr       bool
 	}{
 		{
-			name: "Test on variation returned when flag is on",
+			name:          "Test on variation returned when flag is on",
 			featureConfig: makeFeatureConfig(jsonflagName, jsonKind, on, off, on, FeatureStateOn, nil),
-			want: on,
-			wantErr: false,
+			want:          on,
+			wantErr:       false,
 		},
 		{
-			name: "Test off variation returned when flag is off",
+			name:          "Test off variation returned when flag is off",
 			featureConfig: makeFeatureConfig(jsonflagName, jsonKind, on, off, on, FeatureStateOff, nil),
-			want: off,
-			wantErr: false,
+			want:          off,
+			wantErr:       false,
 		},
 		{
-			name: "Test error returned when invalid default serve is provided",
+			name:          "Test error returned when invalid default serve is provided",
 			featureConfig: makeFeatureConfig(jsonflagName, jsonKind, on, off, other, FeatureStateOn, nil),
-			want: Variation{},
-			wantErr: true,
+			want:          Variation{},
+			wantErr:       true,
 		},
 	}
 	for _, tt := range tests {
@@ -104,46 +102,46 @@ func TestFeatureConfig_StringVariation(t *testing.T) {
 	stringflagName := "SimpleString"
 
 	on := Variation{
-		Name: stringPtr("On"),
-		Value: "v1",
+		Name:       stringPtr("On"),
+		Value:      "v1",
 		Identifier: "on",
 	}
 
 	off := Variation{
-		Name: stringPtr("Off"),
-		Value: "v2",
+		Name:       stringPtr("Off"),
+		Value:      "v2",
 		Identifier: "off",
 	}
 
 	other := Variation{
-		Name: stringPtr("Other"),
-		Value: "v3",
+		Name:       stringPtr("Other"),
+		Value:      "v3",
 		Identifier: "other",
 	}
 
 	tests := []struct {
-		name   string
+		name          string
 		featureConfig FeatureConfig
-		want   Variation
-		wantErr bool
+		want          Variation
+		wantErr       bool
 	}{
 		{
-			name: "Test on variation returned when flag is on",
+			name:          "Test on variation returned when flag is on",
 			featureConfig: makeFeatureConfig(stringflagName, stringKind, on, off, on, FeatureStateOn, nil),
-			want: on,
-			wantErr: false,
+			want:          on,
+			wantErr:       false,
 		},
 		{
-			name: "Test off variation returned when flag is off",
+			name:          "Test off variation returned when flag is off",
 			featureConfig: makeFeatureConfig(stringflagName, stringKind, on, off, on, FeatureStateOff, nil),
-			want: off,
-			wantErr: false,
+			want:          off,
+			wantErr:       false,
 		},
 		{
-			name: "Test error returned when invalid default serve is provided",
+			name:          "Test error returned when invalid default serve is provided",
 			featureConfig: makeFeatureConfig(stringflagName, stringKind, on, off, other, FeatureStateOn, nil),
-			want: Variation{},
-			wantErr: true,
+			want:          Variation{},
+			wantErr:       true,
 		},
 	}
 	for _, tt := range tests {
@@ -164,46 +162,46 @@ func TestFeatureConfig_NumberVariation(t *testing.T) {
 	numberflagName := "SimpleNumber"
 
 	on := Variation{
-		Name: stringPtr("On"),
-		Value: strconv.FormatFloat(1.0, 'f', -1, 64),
+		Name:       stringPtr("On"),
+		Value:      strconv.FormatFloat(1.0, 'f', -1, 64),
 		Identifier: "on",
 	}
 
 	off := Variation{
-		Name: stringPtr("Off"),
-		Value: strconv.FormatFloat(2.0, 'f', -1, 64),
+		Name:       stringPtr("Off"),
+		Value:      strconv.FormatFloat(2.0, 'f', -1, 64),
 		Identifier: "off",
 	}
 
 	other := Variation{
-		Name: stringPtr("Other"),
-		Value: strconv.FormatFloat(3.0, 'f', -1, 64),
+		Name:       stringPtr("Other"),
+		Value:      strconv.FormatFloat(3.0, 'f', -1, 64),
 		Identifier: "other",
 	}
 
 	tests := []struct {
-		name   string
+		name          string
 		featureConfig FeatureConfig
-		want   Variation
-		wantErr bool
+		want          Variation
+		wantErr       bool
 	}{
 		{
-			name: "Test on variation returned when flag is on",
+			name:          "Test on variation returned when flag is on",
 			featureConfig: makeFeatureConfig(numberflagName, numberKind, on, off, on, FeatureStateOn, nil),
-			want: on,
-			wantErr: false,
+			want:          on,
+			wantErr:       false,
 		},
 		{
-			name: "Test off variation returned when flag is off",
+			name:          "Test off variation returned when flag is off",
 			featureConfig: makeFeatureConfig(numberflagName, numberKind, on, off, on, FeatureStateOff, nil),
-			want: off,
-			wantErr: false,
+			want:          off,
+			wantErr:       false,
 		},
 		{
-			name: "Test error returned when invalid default serve is provided",
+			name:          "Test error returned when invalid default serve is provided",
 			featureConfig: makeFeatureConfig(numberflagName, numberKind, on, off, other, FeatureStateOn, nil),
-			want: Variation{},
-			wantErr: true,
+			want:          Variation{},
+			wantErr:       true,
 		},
 	}
 	for _, tt := range tests {
@@ -224,46 +222,46 @@ func TestFeatureConfig_IntVariation(t *testing.T) {
 	intflagName := "SimpleInt"
 
 	on := Variation{
-		Name: stringPtr("On"),
-		Value: strconv.FormatInt(4, 10),
+		Name:       stringPtr("On"),
+		Value:      strconv.FormatInt(4, 10),
 		Identifier: "on",
 	}
 
 	off := Variation{
-		Name: stringPtr("Off"),
-		Value: strconv.FormatInt(9, 10),
+		Name:       stringPtr("Off"),
+		Value:      strconv.FormatInt(9, 10),
 		Identifier: "off",
 	}
 
 	other := Variation{
-		Name: stringPtr("Other"),
-		Value: strconv.FormatInt(19, 10),
+		Name:       stringPtr("Other"),
+		Value:      strconv.FormatInt(19, 10),
 		Identifier: "other",
 	}
 
 	tests := []struct {
-		name   string
+		name          string
 		featureConfig FeatureConfig
-		want   Variation
-		wantErr bool
+		want          Variation
+		wantErr       bool
 	}{
 		{
-			name: "Test on variation returned when flag is on",
+			name:          "Test on variation returned when flag is on",
 			featureConfig: makeFeatureConfig(intflagName, intKind, on, off, on, FeatureStateOn, nil),
-			want: on,
-			wantErr: false,
+			want:          on,
+			wantErr:       false,
 		},
 		{
-			name: "Test off variation returned when flag is off",
+			name:          "Test off variation returned when flag is off",
 			featureConfig: makeFeatureConfig(intflagName, intKind, on, off, on, FeatureStateOff, nil),
-			want: off,
-			wantErr: false,
+			want:          off,
+			wantErr:       false,
 		},
 		{
-			name: "Test error returned when invalid default serve is provided",
+			name:          "Test error returned when invalid default serve is provided",
 			featureConfig: makeFeatureConfig(intflagName, intKind, on, off, other, FeatureStateOn, nil),
-			want: Variation{},
-			wantErr: true,
+			want:          Variation{},
+			wantErr:       true,
 		},
 	}
 	for _, tt := range tests {
@@ -383,7 +381,7 @@ func TestServingRules_GetVariationName(t *testing.T) {
 func makeIdentifierRule(values []string, operator, variationToServe string) []ServingRule {
 	rule := ServingRule{
 		Priority: 0,
-		RuleID: uuid.NewString(),
+		RuleID:   uuid.NewString(),
 		Clauses: []Clause{
 			{Attribute: "identifier", ID: "id", Negate: false, Op: operator, Value: values},
 		},
@@ -400,14 +398,14 @@ func makeFeatureConfig(name, kind string, variation1, variation2, defaultServe V
 		DefaultServe: Serve{
 			Variation: &defaultServe.Identifier,
 		},
-		Environment:   "dev",
-		Feature:       name,
-		Kind:          kind,
-		OffVariation:  variation2.Identifier,
-		Rules: rules,
-		Prerequisites: nil,
-		Project:       "default",
-		State:         state,
+		Environment:          "dev",
+		Feature:              name,
+		Kind:                 kind,
+		OffVariation:         variation2.Identifier,
+		Rules:                rules,
+		Prerequisites:        nil,
+		Project:              "default",
+		State:                state,
 		VariationToTargetMap: nil,
 		Variations: []Variation{
 			{Description: nil, Identifier: variation1.Identifier, Name: variation1.Name, Value: variation1.Value},
@@ -429,14 +427,14 @@ func TestFeatureConfig_Evaluate(t *testing.T) {
 	boolFlagName := "SimpleBool"
 
 	onBool := Variation{
-		Name: stringPtr("On"),
-		Value: "true",
+		Name:       stringPtr("On"),
+		Value:      "true",
 		Identifier: "on",
 	}
 
 	offBool := Variation{
-		Name: stringPtr("Off"),
-		Value: "false",
+		Name:       stringPtr("Off"),
+		Value:      "false",
 		Identifier: "off",
 	}
 
@@ -451,42 +449,42 @@ func TestFeatureConfig_Evaluate(t *testing.T) {
 		target *Target
 	}
 	tests := []struct {
-		name   string
+		name          string
 		featureConfig FeatureConfig
-		args   args
-		want   Evaluation
-		wantErr bool
+		args          args
+		want          Evaluation
+		wantErr       bool
 	}{
 		{
-			name: "Test Bool FeatureConfig with no rules serves variation onBool when on",
+			name:          "Test Bool FeatureConfig with no rules serves variation onBool when on",
 			featureConfig: makeFeatureConfig(boolFlagName, boolKind, onBool, offBool, onBool, FeatureStateOn, nil),
-			args: args{&target},
-			want: Evaluation{Flag:  boolFlagName, Variation: onBool},
-			wantErr: false},
+			args:          args{&target},
+			want:          Evaluation{Flag: boolFlagName, Variation: onBool},
+			wantErr:       false},
 		{
-			name: "Test Bool FeatureConfig Evaluate with no rules serves variation offBool when off",
-			featureConfig: makeFeatureConfig(boolFlagName, boolKind, onBool,offBool, onBool, FeatureStateOff, nil),
-			args: args{&target},
-			want: Evaluation{Flag:  boolFlagName, Variation: offBool},
-			wantErr: false},
+			name:          "Test Bool FeatureConfig Evaluate with no rules serves variation offBool when off",
+			featureConfig: makeFeatureConfig(boolFlagName, boolKind, onBool, offBool, onBool, FeatureStateOff, nil),
+			args:          args{&target},
+			want:          Evaluation{Flag: boolFlagName, Variation: offBool},
+			wantErr:       false},
 		{
-			name: "Test Bool FeatureConfig Evaluate with 'attribute equals rule' serves offBool on match when flag on",
-			featureConfig: makeFeatureConfig(boolFlagName, boolKind, onBool, offBool, onBool, FeatureStateOn, makeIdentifierRule([]string{harness},equalOperator, offBool.Identifier)),
-		    args: args{&target},
-			want: Evaluation{Flag:  boolFlagName, Variation: offBool},
-			wantErr: false},
+			name:          "Test Bool FeatureConfig Evaluate with 'attribute equals rule' serves offBool on match when flag on",
+			featureConfig: makeFeatureConfig(boolFlagName, boolKind, onBool, offBool, onBool, FeatureStateOn, makeIdentifierRule([]string{harness}, equalOperator, offBool.Identifier)),
+			args:          args{&target},
+			want:          Evaluation{Flag: boolFlagName, Variation: offBool},
+			wantErr:       false},
 		{
-			name: "Test Bool FeatureConfig Evaluate with 'attribute equals rule' serves onBool on non-match when flag on",
-			featureConfig: makeFeatureConfig(boolFlagName, boolKind, onBool, offBool, onBool, FeatureStateOn, makeIdentifierRule([]string{"foobar"},equalOperator, offBool.Identifier)),
-			args: args{&target},
-			want: Evaluation{Flag:  boolFlagName, Variation: onBool},
-			wantErr: false},
+			name:          "Test Bool FeatureConfig Evaluate with 'attribute equals rule' serves onBool on non-match when flag on",
+			featureConfig: makeFeatureConfig(boolFlagName, boolKind, onBool, offBool, onBool, FeatureStateOn, makeIdentifierRule([]string{"foobar"}, equalOperator, offBool.Identifier)),
+			args:          args{&target},
+			want:          Evaluation{Flag: boolFlagName, Variation: onBool},
+			wantErr:       false},
 	}
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
 			fc := tc.featureConfig
-			got, err := fc.Evaluate(tc.args.target);
+			got, err := fc.Evaluate(tc.args.target)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("BoolVariation() error = %v, wantErr %v", err, tc.wantErr)
 				return


### PR DESCRIPTION
What:
This change returns a variation struct rather than just the value
from an evaluation call.

Why:
In some circumstances we need both the value of the variation and its identifier.
By returning the variation the caller gets all this information.

The Client API remains unchanged, where BoolVariation will simply return a bool.