### PR TITLE
[FFM-1219]: Fix how segment rules are processed

### DIFF
--- a/evaluation/feature.go
+++ b/evaluation/feature.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/labstack/gommon/log"
+	"github.com/drone/ff-golang-server-sdk/log"
 
 	"github.com/drone/ff-golang-server-sdk/types"
 )
@@ -88,7 +88,7 @@ func (c Clauses) Evaluate(target *Target, segments Segments) bool {
 		// operator should be evaluated based on type of attribute
 		op, err := target.GetOperator(clause.Attribute)
 		if err != nil {
-			fmt.Print(err)
+			log.Warn(err)
 		}
 		if !clause.Evaluate(target, segments, op) {
 			return false

--- a/evaluation/target.go
+++ b/evaluation/target.go
@@ -46,6 +46,6 @@ func (t Target) GetOperator(attr string) (types.ValueType, error) {
 		reflect.Invalid, reflect.Map, reflect.Ptr, reflect.Slice, reflect.Struct, reflect.Uintptr, reflect.UnsafePointer:
 		fallthrough
 	default:
-		return nil, fmt.Errorf("unexpected type: %s", value.Kind().String())
+		return nil, fmt.Errorf("unexpected type: %s\n", value.Kind().String())
 	}
 }

--- a/evaluation/target.go
+++ b/evaluation/target.go
@@ -46,6 +46,6 @@ func (t Target) GetOperator(attr string) (types.ValueType, error) {
 		reflect.Invalid, reflect.Map, reflect.Ptr, reflect.Slice, reflect.Struct, reflect.Uintptr, reflect.UnsafePointer:
 		fallthrough
 	default:
-		return nil, fmt.Errorf("unexpected type: %s\n", value.Kind().String())
+		return nil, fmt.Errorf("unexpected type: %s", value.Kind().String())
 	}
 }

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,66 @@
+package log
+
+import "github.com/drone/ff-golang-server-sdk/logger"
+
+// And just go global.
+var defaultLogger logger.Logger
+
+// init creates the default logger.  This can be changed
+func init() {
+	defaultLogger, _ = logger.NewZapLogger(false)
+}
+
+// SetLogger sets the default logger to be used by this package
+func SetLogger(logger logger.Logger) {
+	defaultLogger = logger
+}
+
+// Error logs an error message with the parameters
+func Error(args ...interface{}) {
+	defaultLogger.Error(args...)
+}
+
+// Errorf logs a formatted error message
+func Errorf(format string, args ...interface{}) {
+	defaultLogger.Errorf(format, args...)
+}
+
+// Fatalf logs a formatted fatal message.  This will terminate the application
+func Fatalf(format string, args ...interface{}) {
+	defaultLogger.Fatalf(format, args...)
+}
+
+// Fatal logs an fatal message with the parameters.  This will terminate the application
+func Fatal(args ...interface{}) {
+	defaultLogger.Fatal(args...)
+}
+
+// Infof logs a formatted info message
+func Infof(format string, args ...interface{}) {
+	defaultLogger.Infof(format, args...)
+}
+
+// Info logs an info message with the parameters
+func Info(args ...interface{}) {
+	defaultLogger.Info(args...)
+}
+
+// Warn logs an warn message with the parameters
+func Warn(args ...interface{}) {
+	defaultLogger.Warn(args...)
+}
+
+// Warnf logs a formatted warn message
+func Warnf(format string, args ...interface{}) {
+	defaultLogger.Warnf(format, args...)
+}
+
+// Debugf logs a formatted debug message
+func Debugf(format string, args ...interface{}) {
+	defaultLogger.Debugf(format, args...)
+}
+
+// Debug logs an debug message with the parameters
+func Debug(args ...interface{}) {
+	defaultLogger.Debug(args...)
+}

--- a/rest/adapter.go
+++ b/rest/adapter.go
@@ -1,6 +1,8 @@
 package rest
 
-import "github.com/drone/ff-golang-server-sdk/evaluation"
+import (
+	"github.com/drone/ff-golang-server-sdk/evaluation"
+)
 
 func (wv WeightedVariation) convert() *evaluation.WeightedVariation {
 	return &evaluation.WeightedVariation{
@@ -144,7 +146,7 @@ func (s Segment) Convert() evaluation.Segment {
 	if s.Excluded != nil {
 		excluded = make(evaluation.StrSlice, len(*s.Excluded))
 		for i, excl := range *s.Excluded {
-			excluded[i] = excl.Name
+			excluded[i] = excl.Identifier
 		}
 	}
 
@@ -152,13 +154,13 @@ func (s Segment) Convert() evaluation.Segment {
 	if s.Included != nil {
 		included = make(evaluation.StrSlice, len(*s.Included))
 		for i, incl := range *s.Included {
-			included[i] = incl.Name
+			included[i] = incl.Identifier
 		}
 	}
 
-	rules := make(evaluation.Clauses, 0)
+	rules := make(evaluation.SegmentRules, 0)
 	if s.Rules != nil {
-		rules = make(evaluation.Clauses, len(*s.Rules))
+		rules = make(evaluation.SegmentRules, len(*s.Rules))
 		for i, rule := range *s.Rules {
 			rules[i] = evaluation.Clause{
 				Attribute: rule.Attribute,


### PR DESCRIPTION
What:
  * change logic so the include/exclude rules use target identifier rather name to be consistent
  with how the rules are stored.
  * Make exclude list take precedence over include list and rules.
  * Process segment rules as OR rather than AND.

Why:
  When creating segment include/exclude lists the server only stores target identifiers not
  names, so this logic needed to be updated so the lists were correctly evaluated.

  The exclude list was being evaluated last, which meant we could not include all users via
  a rule, but exclude one via a list.  This is consistent with how the Java SDK behaves.

  Segment rules should be OR'd, but they were being treated like flag clauses and were being
  AND'd which meant conflicting rules would prevent targets from correctly being included.