### PR TITLE
[FFM-1251]: Rules for flags added directly to segment not working

### DIFF
--- a/evaluation/feature.go
+++ b/evaluation/feature.go
@@ -161,6 +161,12 @@ func (fc FeatureConfig) GetSegmentIdentifiers() StrSlice {
 			}
 		}
 	}
+
+	// Append any segments that come from the variation target map
+	// in addition to the rules above
+	for _, x := range fc.VariationToTargetMap {
+		slice = append(slice, x.TargetSegments...)
+	}
 	return slice
 }
 

--- a/evaluation/feature.go
+++ b/evaluation/feature.go
@@ -164,8 +164,8 @@ func (fc FeatureConfig) GetSegmentIdentifiers() StrSlice {
 
 	// Append any segments that come from the variation target map
 	// in addition to the rules above
-	for _, x := range fc.VariationToTargetMap {
-		slice = append(slice, x.TargetSegments...)
+	for _, targetMap := range fc.VariationToTargetMap {
+		slice = append(slice, targetMap.TargetSegments...)
 	}
 	return slice
 }


### PR DESCRIPTION
What:
Append segments from the target segment variation map, to the list of segments
that should be loaded by a feature config.

Why:
There are two ways to add a segment to a flag.

1) From segments added through flag rules
2) From segments in the variation target map.

The first use-case worked, because we parse the rules and create a list of segments to load
from the cache, prior to evaluating rules.
The second use-case did not work, as we didn't append segments from the variation target map
in the list.