### PR TITLE
(FFM-1290) Ignored empty evaliation attibute

### DIFF
--- a/evaluation/target.go
+++ b/evaluation/target.go
@@ -31,6 +31,9 @@ func (t Target) GetAttrValue(attr string) reflect.Value {
 
 // GetOperator returns interface based on attribute value
 func (t Target) GetOperator(attr string) (types.ValueType, error) {
+	if attr == "" {
+		return nil, nil
+	}
 	value := t.GetAttrValue(attr)
 	switch value.Kind() {
 	case reflect.Bool:

--- a/evaluation/target_test.go
+++ b/evaluation/target_test.go
@@ -59,6 +59,13 @@ func TestTarget_GetOperator(t1 *testing.T) {
 			"weight": 99.99,
 		}},
 			args: struct{ attr string }{attr: "weight"}, want: types.Number(99.99)},
+		{name: "empty operator", fields: struct {
+			Identifier string
+			Name       *string
+			Anonymous  bool
+			Attributes map[string]interface{}
+		}{Identifier: "harness", Name: nil, Anonymous: false, Attributes: map[string]interface{}{}},
+			args: struct{ attr string }{attr: ""}, want: nil},
 	}
 	for _, tt := range tests {
 		val := tt


### PR DESCRIPTION
*what*

When you add a 'target group match' rule to a flag the attribute field is empty. So we would show an invalid type error. this change simply ignores empty attributes. 

*Why*
Otherwise we would display a warning log each time that the type is invalid, despite the fact that it is ok.