### PR TITLE
[FFM-1355]: SDK doesn't support multiple custom attributes and name no…

### DIFF
--- a/analyticsservice/analytics.go
+++ b/analyticsservice/analytics.go
@@ -151,8 +151,8 @@ func (as *AnalyticsService) sendDataAndResetCache(ctx context.Context) {
 				}
 
 				targetName := analytic.target.Identifier
-				if analytic.target.Name != nil {
-					targetName = *analytic.target.Name
+				if analytic.target.Name != "" {
+					targetName = analytic.target.Name
 				}
 
 				td := metricsclient.TargetData{

--- a/client/client.go
+++ b/client/client.go
@@ -191,7 +191,7 @@ func (c *CfClient) authenticate(ctx context.Context, target evaluation.Target) {
 		target.Anonymous,
 		target.Attributes,
 		target.Identifier,
-		target.Name,
+		&target.Name,
 	}
 	c.auth.Target = &t
 	c.mux.RLock()

--- a/dto/target_builder.go
+++ b/dto/target_builder.go
@@ -63,7 +63,7 @@ func (b *targetBuilder) Lastname(lastname string) TargetBuilderInterface {
 
 // Name target name object
 func (b *targetBuilder) Name(name string) TargetBuilderInterface {
-	b.Custom("name", name)
+	b.Target.Name = name
 	return b
 }
 
@@ -76,8 +76,8 @@ func (b *targetBuilder) Anonymous(value bool) TargetBuilderInterface {
 // Custom object
 func (b *targetBuilder) Custom(key string, value interface{}) TargetBuilderInterface {
 	m := make(map[string]interface{})
-	if b.Target.Attributes == nil {
-		b.Target.Attributes = &m
+	if b.Target.Attributes != nil {
+		m = *b.Target.Attributes
 	}
 	m[key] = value
 	b.Target.Attributes = &m

--- a/evaluation/feature_test.go
+++ b/evaluation/feature_test.go
@@ -298,7 +298,7 @@ func TestServingRules_GetVariationName(t *testing.T) {
 	}
 	target := &Target{
 		Identifier: harness,
-		Name:       &harness,
+		Name:       harness,
 		Anonymous:  &f,
 		Attributes: &m,
 	}
@@ -482,7 +482,6 @@ func TestFeatureConfig_Evaluate(t *testing.T) {
 
 	target := Target{
 		Identifier: harness,
-		Name:       nil,
 		Anonymous:  &f,
 		Attributes: &m,
 	}
@@ -554,7 +553,6 @@ func TestClause_Evaluate(t *testing.T) {
 	m["email"] = "john@doe.com"
 	target := Target{
 		Identifier: "john",
-		Name:       nil,
 		Anonymous:  &f,
 		Attributes: &m,
 	}

--- a/evaluation/reflection_test.go
+++ b/evaluation/reflection_test.go
@@ -13,7 +13,7 @@ func TestGetStructFieldValue(t *testing.T) {
 	f := false
 	target := Target{
 		Identifier: identifier,
-		Name:       &name,
+		Name:       name,
 		Anonymous:  &f,
 		Attributes: &m,
 	}
@@ -61,7 +61,7 @@ func Test_caseInsensitiveFieldByName(t *testing.T) {
 	f := false
 	target := Target{
 		Identifier: identifier,
-		Name:       &name,
+		Name:       name,
 		Anonymous:  &f,
 		Attributes: &m,
 	}

--- a/evaluation/segment_test.go
+++ b/evaluation/segment_test.go
@@ -17,7 +17,6 @@ func TestSegment_Evaluate(t *testing.T) {
 	m["email"] = "john@doe.com"
 	target := Target{
 		Identifier: "john",
-		Name:       nil,
 		Anonymous:  &f,
 		Attributes: &m,
 	}

--- a/evaluation/target.go
+++ b/evaluation/target.go
@@ -2,6 +2,7 @@ package evaluation
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/drone/ff-golang-server-sdk/types"
 
@@ -11,7 +12,7 @@ import (
 // Target object
 type Target struct {
 	Identifier string
-	Name       *string
+	Name       string
 	Anonymous  *bool
 	Attributes *map[string]interface{}
 }
@@ -24,7 +25,14 @@ func (t Target) GetAttrValue(attr string) reflect.Value {
 	if ok {
 		value = reflect.ValueOf(attrVal)
 	} else {
-		value = GetStructFieldValue(t, attr)
+		// We only have two fields here, so we will access the fields directly, and use reflection if we start adding
+		// more in the future
+		switch strings.ToLower(attr) {
+		case "identifier":
+			value = reflect.ValueOf(t.Identifier)
+		case "name":
+			value = reflect.ValueOf(t.Name)
+		}
 	}
 	return value
 }

--- a/evaluation/target_test.go
+++ b/evaluation/target_test.go
@@ -13,7 +13,7 @@ func TestTarget_GetOperator(t1 *testing.T) {
 	m["anonymous"] = false
 	type fields struct {
 		Identifier string
-		Name       *string
+		Name       string
 		Anonymous  bool
 		Attributes map[string]interface{}
 	}
@@ -29,42 +29,42 @@ func TestTarget_GetOperator(t1 *testing.T) {
 	}{
 		{name: "boolean operator", fields: struct {
 			Identifier string
-			Name       *string
+			Name       string
 			Anonymous  bool
 			Attributes map[string]interface{}
-		}{Identifier: "harness", Name: &harness, Anonymous: false, Attributes: m},
+		}{Identifier: "harness", Name: harness, Anonymous: false, Attributes: m},
 			args: struct{ attr string }{attr: "anonymous"}, want: types.Boolean(false)},
 		{name: "string operator", fields: struct {
 			Identifier string
-			Name       *string
+			Name       string
 			Anonymous  bool
 			Attributes map[string]interface{}
-		}{Identifier: "harness", Name: &harness, Anonymous: false, Attributes: nil},
+		}{Identifier: "harness", Name: harness, Anonymous: false, Attributes: nil},
 			args: struct{ attr string }{attr: "identifier"}, want: types.String("harness")},
 		{name: "int operator", fields: struct {
 			Identifier string
-			Name       *string
+			Name       string
 			Anonymous  bool
 			Attributes map[string]interface{}
-		}{Identifier: "harness", Name: &harness, Anonymous: false, Attributes: map[string]interface{}{
+		}{Identifier: "harness", Name: harness, Anonymous: false, Attributes: map[string]interface{}{
 			"order": 1,
 		}},
 			args: struct{ attr string }{attr: "order"}, want: types.Integer(1)},
 		{name: "number operator", fields: struct {
 			Identifier string
-			Name       *string
+			Name       string
 			Anonymous  bool
 			Attributes map[string]interface{}
-		}{Identifier: "harness", Name: &harness, Anonymous: false, Attributes: map[string]interface{}{
+		}{Identifier: "harness", Name: harness, Anonymous: false, Attributes: map[string]interface{}{
 			"weight": 99.99,
 		}},
 			args: struct{ attr string }{attr: "weight"}, want: types.Number(99.99)},
 		{name: "empty operator", fields: struct {
 			Identifier string
-			Name       *string
+			Name       string
 			Anonymous  bool
 			Attributes map[string]interface{}
-		}{Identifier: "harness", Name: nil, Anonymous: false, Attributes: map[string]interface{}{}},
+		}{Identifier: "harness", Anonymous: false, Attributes: map[string]interface{}{}},
 			args: struct{ attr string }{attr: ""}, want: nil},
 	}
 	for _, tt := range tests {
@@ -94,7 +94,7 @@ func TestTarget_GetAttrValue(t1 *testing.T) {
 	email := "john@doe.com"
 	type fields struct {
 		Identifier string
-		Name       *string
+		Name       string
 		Anonymous  bool
 		Attributes map[string]interface{}
 	}
@@ -109,17 +109,17 @@ func TestTarget_GetAttrValue(t1 *testing.T) {
 	}{
 		{name: "check identifier", fields: struct {
 			Identifier string
-			Name       *string
+			Name       string
 			Anonymous  bool
 			Attributes map[string]interface{}
-		}{Identifier: identifier, Name: &name, Anonymous: false, Attributes: types.JSON{}},
+		}{Identifier: identifier, Name: name, Anonymous: false, Attributes: types.JSON{}},
 			args: struct{ attr string }{attr: "identifier"}, want: reflect.ValueOf(identifier)},
 		{name: "check attributes", fields: struct {
 			Identifier string
-			Name       *string
+			Name       string
 			Anonymous  bool
 			Attributes map[string]interface{}
-		}{Identifier: "john", Name: &name, Anonymous: false, Attributes: types.JSON{
+		}{Identifier: "john", Name: name, Anonymous: false, Attributes: types.JSON{
 			"email": email,
 		}},
 			args: struct{ attr string }{attr: "email"}, want: reflect.ValueOf(email)},
@@ -145,7 +145,7 @@ func TestTarget_GetOperator1(t1 *testing.T) {
 	m["anonymous"] = false
 	type fields struct {
 		Identifier string
-		Name       *string
+		Name       string
 		Anonymous  bool
 		Attributes map[string]interface{}
 	}
@@ -163,33 +163,33 @@ func TestTarget_GetOperator1(t1 *testing.T) {
 	}{
 		{name: "bool operator", fields: struct {
 			Identifier string
-			Name       *string
+			Name       string
 			Anonymous  bool
 			Attributes map[string]interface{}
-		}{Identifier: "john", Name: &name, Anonymous: false, Attributes: types.JSON{"anonymous": false}},
+		}{Identifier: "john", Name: name, Anonymous: false, Attributes: types.JSON{"anonymous": false}},
 			args: struct{ attr string }{attr: "anonymous"}, want: types.Boolean(false)},
 		{name: "string operator", fields: struct {
 			Identifier string
-			Name       *string
+			Name       string
 			Anonymous  bool
 			Attributes map[string]interface{}
-		}{Identifier: "john", Name: &name, Anonymous: false, Attributes: types.JSON{}},
+		}{Identifier: "john", Name: name, Anonymous: false, Attributes: types.JSON{}},
 			args: struct{ attr string }{attr: "identifier"}, want: types.String("john")},
 		{name: "number operator", fields: struct {
 			Identifier string
-			Name       *string
+			Name       string
 			Anonymous  bool
 			Attributes map[string]interface{}
-		}{Identifier: "john", Name: &name, Anonymous: false, Attributes: types.JSON{
+		}{Identifier: "john", Name: name, Anonymous: false, Attributes: types.JSON{
 			"height": 186.5,
 		}},
 			args: struct{ attr string }{attr: "height"}, want: types.Number(186.5)},
 		{name: "integer operator", fields: struct {
 			Identifier string
-			Name       *string
+			Name       string
 			Anonymous  bool
 			Attributes map[string]interface{}
-		}{Identifier: "john", Name: &name, Anonymous: false, Attributes: types.JSON{
+		}{Identifier: "john", Name: name, Anonymous: false, Attributes: types.JSON{
 			"zip": 90210,
 		}},
 			args: struct{ attr string }{attr: "zip"}, want: types.Integer(90210)},


### PR DESCRIPTION
…t set correctly

The Target builder replaces the attributes map with every new custom attribute.  This means
we only ever could have one custom attribute.

Name was stored as a custom attribute instead of as a named field, the problem is if you have
the Java SDK using the same target, then it sends 'name' as a named field, and so conflicts with
custom attributes.

This PR fixes the issue with the custom attributes and ensures name is stored in a named field.