### PR TITLE
[FFM-1452]: Fix bool, int and number comparisons + implement slices

### DIFF
--- a/evaluation/target.go
+++ b/evaluation/target.go
@@ -53,8 +53,10 @@ func (t Target) GetOperator(attr string) (types.ValueType, error) {
 	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int8, reflect.Uint, reflect.Uint16,
 		reflect.Uint32, reflect.Uint64, reflect.Uint8:
 		return types.Integer(value.Int()), nil
+	case reflect.Slice:
+		return types.NewSlice(value.Interface()), nil
 	case reflect.Array, reflect.Chan, reflect.Complex128, reflect.Complex64, reflect.Func, reflect.Interface,
-		reflect.Invalid, reflect.Map, reflect.Ptr, reflect.Slice, reflect.Struct, reflect.Uintptr, reflect.UnsafePointer:
+		reflect.Invalid, reflect.Map, reflect.Ptr, reflect.Struct, reflect.Uintptr, reflect.UnsafePointer:
 		fallthrough
 	default:
 		return nil, fmt.Errorf("unexpected type: %s", value.Kind().String())

--- a/types/bool.go
+++ b/types/bool.go
@@ -2,6 +2,9 @@ package types
 
 import (
 	"fmt"
+	"strconv"
+
+	"github.com/drone/ff-golang-server-sdk/log"
 )
 
 // Boolean type for clause attribute evaluation
@@ -17,61 +20,70 @@ func NewBoolean(value interface{}) (*Boolean, error) {
 	return nil, fmt.Errorf("%v: cant cast to a booelan", ErrWrongTypeAssertion)
 }
 
-// StartsWith always return false
-func (b Boolean) StartsWith(value interface{}) bool {
-	return false
-}
-
-// EndsWith always return false
-func (b Boolean) EndsWith(value interface{}) bool {
-	return false
-}
-
-// Match always return false
-func (b Boolean) Match(value interface{}) bool {
-	return false
-}
-
-// Contains always return false
-func (b Boolean) Contains(value interface{}) bool {
-	return false
-}
-
-// EqualSensitive always return false
-func (b Boolean) EqualSensitive(value interface{}) bool {
-	return false
-}
-
-// Equal check if the boolean and value are equal
-func (b Boolean) Equal(value interface{}) bool {
-	val, ok := value.(bool)
-	if ok {
-		return Boolean(val) == b
+// numberOperator iterates over value, convets it to a float64 and calls fn on each element
+func boolOperator(value []string, fn func(bool) bool) bool {
+	if len(value) > 0 {
+		if i, err := strconv.ParseBool(value[0]); err == nil {
+			return fn(i)
+		}
+		log.Warnf("input contains invalid value for bool comparisons: %s\n", value)
 	}
 	return false
 }
 
+// StartsWith always return false
+func (b Boolean) StartsWith(value []string) bool {
+	return false
+}
+
+// EndsWith always return false
+func (b Boolean) EndsWith(value []string) bool {
+	return false
+}
+
+// Match always return false
+func (b Boolean) Match(value []string) bool {
+	return false
+}
+
+// Contains always return false
+func (b Boolean) Contains(value []string) bool {
+	return false
+}
+
+// EqualSensitive always return false
+func (b Boolean) EqualSensitive(value []string) bool {
+	return false
+}
+
+// Equal check if the boolean and value are equal
+func (b Boolean) Equal(value []string) bool {
+	return boolOperator(value, func(f bool) bool {
+		return bool(b) == f
+	})
+}
+
 // GreaterThan always return false
-func (b Boolean) GreaterThan(value interface{}) bool {
+func (b Boolean) GreaterThan(value []string) bool {
 	return false
 }
 
 // GreaterThanEqual always return false
-func (b Boolean) GreaterThanEqual(value interface{}) bool {
+func (b Boolean) GreaterThanEqual(value []string) bool {
 	return false
 }
 
 // LessThan always return false
-func (b Boolean) LessThan(value interface{}) bool {
+func (b Boolean) LessThan(value []string) bool {
 	return false
 }
 
 // LessThanEqual always return false
-func (b Boolean) LessThanEqual(value interface{}) bool {
+func (b Boolean) LessThanEqual(value []string) bool {
 	return false
 }
 
 // In always return false
-func (b Boolean) In(value interface{}) bool {
+func (b Boolean) In(value []string) bool {
 	return false
 }

--- a/types/bool.go
+++ b/types/bool.go
@@ -20,7 +20,7 @@ func NewBoolean(value interface{}) (*Boolean, error) {
 	return nil, fmt.Errorf("%v: cant cast to a booelan", ErrWrongTypeAssertion)
 }
 
-// numberOperator iterates over value, convets it to a float64 and calls fn on each element
+// boolOperator iterates over value, converts it to a float64 and calls fn on each element
 func boolOperator(value []string, fn func(bool) bool) bool {
 	if len(value) > 0 {
 		if i, err := strconv.ParseBool(value[0]); err == nil {

--- a/types/bool_test.go
+++ b/types/bool_test.go
@@ -1,0 +1,25 @@
+package types
+
+import "testing"
+
+func TestBoolean_Equal(t *testing.T) {
+	tests := []struct {
+		name string
+		b    Boolean
+		args []string
+		want bool
+	}{
+		{"test equal returns true with match", Boolean(true), []string{"true"}, true},
+		{"test equal returns false when no match", Boolean(true), []string{"false"}, false},
+		{"test equal returns true with multiple values", Boolean(false), []string{"false", "true"}, true},
+		{"test equal only matches first value", Boolean(false), []string{"true", "false"}, false},
+		{"test equal returns false for invalid value", Boolean(true), []string{"on"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.b.Equal(tt.args); got != tt.want {
+				t.Errorf("Equal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/types/int.go
+++ b/types/int.go
@@ -2,6 +2,9 @@ package types
 
 import (
 	"fmt"
+	"strconv"
+
+	"github.com/drone/ff-golang-server-sdk/log"
 )
 
 // Integer type for clause attribute evaluation
@@ -17,82 +20,86 @@ func NewInteger(value interface{}) (*Integer, error) {
 	return nil, fmt.Errorf("%v: cant cast to a integer", ErrWrongTypeAssertion)
 }
 
-func (n Integer) operator(value interface{}, fn func(int64) bool) bool {
-	num, ok := value.([]int64)
-	if ok {
-		return fn(num[0])
+// intOperator takes the first element from the slice, converts it to a int64 and passes to fn for processing.
+// we ignore any additional elements if they exist.
+func intOperator(value []string, fn func(int64) bool) bool {
+	if len(value) > 0 {
+		if i, err := strconv.ParseInt(value[0], 10, 64); err == nil {
+			if fn(i) {
+				return true
+			}
+		}
+		log.Warnf("input contains invalid value for integer comparisons: %s\n", value)
 	}
+
 	return false
 }
 
 // StartsWith always return false
-func (n Integer) StartsWith(interface{}) bool {
+func (n Integer) StartsWith([]string) bool {
 	return false
 }
 
 // EndsWith always return false
-func (n Integer) EndsWith(interface{}) bool {
+func (n Integer) EndsWith([]string) bool {
 	return false
 }
 
 // Match always return false
-func (n Integer) Match(interface{}) bool {
+func (n Integer) Match([]string) bool {
 	return false
 }
 
 // Contains always return false
-func (n Integer) Contains(interface{}) bool {
+func (n Integer) Contains([]string) bool {
 	return false
 }
 
 // EqualSensitive always return false
-func (n Integer) EqualSensitive(interface{}) bool {
+func (n Integer) EqualSensitive([]string) bool {
 	return false
 }
 
 // Equal check if the number and value are equal
-func (n Integer) Equal(value interface{}) bool {
-	return n.operator(value, func(f int64) bool {
+func (n Integer) Equal(value []string) bool {
+	return intOperator(value, func(f int64) bool {
 		return int64(n) == f
 	})
 }
 
 // GreaterThan checks if the number is greater than the value
-func (n Integer) GreaterThan(value interface{}) bool {
-	return n.operator(value, func(f int64) bool {
+func (n Integer) GreaterThan(value []string) bool {
+	return intOperator(value, func(f int64) bool {
 		return int64(n) > f
 	})
 }
 
 // GreaterThanEqual checks if the number is greater or equal than the value
-func (n Integer) GreaterThanEqual(value interface{}) bool {
-	return n.operator(value, func(f int64) bool {
+func (n Integer) GreaterThanEqual(value []string) bool {
+	return intOperator(value, func(f int64) bool {
 		return int64(n) >= f
 	})
 }
 
 // LessThan checks if the number is less than the value
-func (n Integer) LessThan(value interface{}) bool {
-	return n.operator(value, func(f int64) bool {
+func (n Integer) LessThan(value []string) bool {
+	return intOperator(value, func(f int64) bool {
 		return int64(n) < f
 	})
 }
 
 // LessThanEqual checks if the number is less or equal than the value
-func (n Integer) LessThanEqual(value interface{}) bool {
-	return n.operator(value, func(f int64) bool {
+func (n Integer) LessThanEqual(value []string) bool {
+	return intOperator(value, func(f int64) bool {
 		return int64(n) <= f
 	})
 }
 
 // In checks if the number exist in slice of numbers (value)
-func (n Integer) In(value interface{}) bool {
-	array, ok := value.([]interface{})
-	if ok {
-		for _, val := range array {
-			if n.Equal(val) {
-				return true
-			}
+func (n Integer) In(value []string) bool {
+	for _, x := range value {
+		if n.Equal([]string{x}) {
+			return true
 		}
 	}
 	return false

--- a/types/int_test.go
+++ b/types/int_test.go
@@ -1,0 +1,26 @@
+package types
+
+import "testing"
+
+func TestInteger_Equal(t *testing.T) {
+
+	tests := []struct {
+		name string
+		n    Integer
+		args []string
+		want bool
+	}{
+		{"test equal returns true with match", Integer(22), []string{"22"}, true},
+		{"test equal returns false when no match", Integer(22), []string{"25"}, false},
+		{"test equal returns true with multiple values", Integer(22), []string{"22", "23"}, true},
+		{"test equal only matches first value", Integer(22), []string{"23", "22"}, false},
+		{"test equal returns false for invalid value", Integer(22), []string{"true"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.n.Equal(tt.args); got != tt.want {
+				t.Errorf("Equal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/types/number.go
+++ b/types/number.go
@@ -2,6 +2,9 @@ package types
 
 import (
 	"fmt"
+	"strconv"
+
+	"github.com/drone/ff-golang-server-sdk/log"
 )
 
 // Number type for clause attribute evaluation
@@ -17,82 +20,85 @@ func NewNumber(value interface{}) (*Number, error) {
 	return nil, fmt.Errorf("%v: cant cast to a number", ErrWrongTypeAssertion)
 }
 
-func (n Number) operator(value interface{}, fn func(float64) bool) bool {
-	num, ok := value.([]float64)
-	if ok {
-		return fn(num[0])
+// numberOperator takes the first element from the slice, converts it to a float64 and passes to fn for processing.
+// we ignore any additional elements if they exist.
+func numberOperator(value []string, fn func(float64) bool) bool {
+	if len(value) > 0 {
+		if i, err := strconv.ParseFloat(value[0], 64); err == nil {
+			if fn(i) {
+				return true
+			}
+		}
+		log.Warnf("input contains invalid value for number comparisons: %s\n", value)
 	}
 	return false
 }
 
 // StartsWith always return false
-func (n Number) StartsWith(value interface{}) bool {
+func (n Number) StartsWith(value []string) bool {
 	return false
 }
 
 // EndsWith always return false
-func (n Number) EndsWith(value interface{}) bool {
+func (n Number) EndsWith(value []string) bool {
 	return false
 }
 
 // Match always return false
-func (n Number) Match(value interface{}) bool {
+func (n Number) Match(value []string) bool {
 	return false
 }
 
 // Contains always return false
-func (n Number) Contains(value interface{}) bool {
+func (n Number) Contains(value []string) bool {
 	return false
 }
 
 // EqualSensitive always return false
-func (n Number) EqualSensitive(value interface{}) bool {
+func (n Number) EqualSensitive(value []string) bool {
 	return false
 }
 
 // Equal check if the number and value are equal
-func (n Number) Equal(value interface{}) bool {
-	return n.operator(value, func(f float64) bool {
+func (n Number) Equal(value []string) bool {
+	return numberOperator(value, func(f float64) bool {
 		return float64(n) == f
 	})
 }
 
 // GreaterThan checks if the number is greater than the value
-func (n Number) GreaterThan(value interface{}) bool {
-	return n.operator(value, func(f float64) bool {
+func (n Number) GreaterThan(value []string) bool {
+	return numberOperator(value, func(f float64) bool {
 		return float64(n) > f
 	})
 }
 
 // GreaterThanEqual checks if the number is greater or equal than the value
-func (n Number) GreaterThanEqual(value interface{}) bool {
-	return n.operator(value, func(f float64) bool {
+func (n Number) GreaterThanEqual(value []string) bool {
+	return numberOperator(value, func(f float64) bool {
 		return float64(n) >= f
 	})
 }
 
 // LessThan checks if the number is less than the value
-func (n Number) LessThan(value interface{}) bool {
-	return n.operator(value, func(f float64) bool {
+func (n Number) LessThan(value []string) bool {
+	return numberOperator(value, func(f float64) bool {
 		return float64(n) < f
 	})
 }
 
 // LessThanEqual checks if the number is less or equal than the value
-func (n Number) LessThanEqual(value interface{}) bool {
-	return n.operator(value, func(f float64) bool {
+func (n Number) LessThanEqual(value []string) bool {
+	return numberOperator(value, func(f float64) bool {
 		return float64(n) <= f
 	})
 }
 
 // In checks if the number exist in slice of numbers (value)
-func (n Number) In(value interface{}) bool {
-	array, ok := value.([]interface{})
-	if ok {
-		for _, val := range array {
-			if n.Equal(val) {
-				return true
-			}
+func (n Number) In(value []string) bool {
+	for _, x := range value {
+		if n.Equal([]string{x}) {
+			return true
 		}
 	}
 	return false

--- a/types/number_test.go
+++ b/types/number_test.go
@@ -1,0 +1,25 @@
+package types
+
+import "testing"
+
+func TestNumber_Equal(t *testing.T) {
+	tests := []struct {
+		name string
+		n    Number
+		args []string
+		want bool
+	}{
+		{"test equal returns true with match", Number(22), []string{"22"}, true},
+		{"test equal returns false when no match", Number(22), []string{"25"}, false},
+		{"test equal returns true with multiple values", Number(22), []string{"22", "23"}, true},
+		{"test equal only matches first value", Number(22), []string{"23", "22"}, false},
+		{"test equal returns false for invalid value", Number(22), []string{"true"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.n.Equal(tt.args); got != tt.want {
+				t.Errorf("Equal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/types/slice.go
+++ b/types/slice.go
@@ -31,34 +31,29 @@ func (s Slice) In(values []string) bool {
 	}
 
 	// Determine what kind of slice we have
-	switch data.(type) {
+	switch attributes := data.(type) {
 	case []string:
-		attributes := data.([]string)
 		for _, attribute := range attributes {
 			if stringcmp(attribute, values) {
 				return true
 			}
 		}
 	case []float64:
-		attributes := data.([]float64)
 		for _, attribute := range attributes {
 			if float64cmp(attribute, values) {
 				return true
 			}
 		}
 	case []bool:
-		attributes := data.([]bool)
 		for _, attribute := range attributes {
 			if boolcmp(attribute, values) {
 				return true
 			}
-
 		}
 	case []interface{}:
 		// case we get a []interface, this can store different types at the same time
 		// e.g the first element could be a string, the next a float, so we need to
 		// iterate over the slice and determine the type of each element
-		attributes := data.([]interface{})
 		for _, attribute := range attributes {
 			switch attr := attribute.(type) {
 			case string:

--- a/types/slice.go
+++ b/types/slice.go
@@ -1,0 +1,172 @@
+package types
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/drone/ff-golang-server-sdk/log"
+)
+
+// Slice type for clause attribute evaluation
+type Slice struct {
+	data interface{}
+}
+
+// NewSlice creates a Slice instance with the object value
+func NewSlice(value interface{}) Slice {
+	return Slice{
+		data: value,
+	}
+}
+
+// In compares the attributes held by the slice with the input values.
+// it will first determine what type of slice this is, before casting values
+// to the appropriate type.
+func (s Slice) In(values []string) bool {
+	// Determine what kind of slice we have
+	switch s.data.(type) {
+	case []string:
+		attributes := s.data.([]string)
+		for _, attribute := range attributes {
+			if stringcmp(attribute, values) {
+				return true
+			}
+		}
+	case []float64:
+		attributes := s.data.([]float64)
+		for _, attribute := range attributes {
+			if float64cmp(attribute, values) {
+				return true
+			}
+		}
+	case []bool:
+		attributes := s.data.([]bool)
+		for _, attribute := range attributes {
+			if boolcmp(attribute, values) {
+				return true
+			}
+
+		}
+	case []interface{}:
+		// case we get a []interface, this can store different types at the same time
+		// e.g the first element could be a string, the next a float, so we need to
+		// iterate over the slice and determine the type of each element
+		attributes := s.data.([]interface{})
+		for _, attribute := range attributes {
+			switch attribute.(type) {
+			case string:
+				if stringcmp(attribute.(string), values) {
+					return true
+				}
+			case float64:
+				if float64cmp(attribute.(float64), values) {
+					return true
+				}
+			case bool:
+				if boolcmp(attribute.(bool), values) {
+					return true
+				}
+			}
+		}
+	default:
+		log.Warn("unsupported attributes for 'in' comparison: [%+v]", s.data)
+
+	}
+
+	return false
+}
+
+// Equal always return false
+func (s Slice) Equal(value []string) bool {
+	return s.In(value)
+}
+
+// Contains always return false
+func (s Slice) Contains(values []string) bool {
+	return s.In(values)
+}
+
+// StartsWith always return false
+func (s Slice) StartsWith(value []string) bool {
+	return false
+}
+
+// EndsWith always return false
+func (s Slice) EndsWith(value []string) bool {
+	return false
+}
+
+// Match always return false
+func (s Slice) Match(value []string) bool {
+	return false
+}
+
+// EqualSensitive always return false
+func (s Slice) EqualSensitive(value []string) bool {
+	return false
+}
+
+// GreaterThan always return false
+func (s Slice) GreaterThan(value []string) bool {
+	return false
+}
+
+// GreaterThanEqual always return false
+func (s Slice) GreaterThanEqual(value []string) bool {
+	return false
+}
+
+// LessThan always return false
+func (s Slice) LessThan(value []string) bool {
+	return false
+}
+
+// LessThanEqual always return false
+func (s Slice) LessThanEqual(value []string) bool {
+	return false
+}
+
+// strcmp compares the attribute with each element in values
+// if any one of values matches it returns true, otherwise false.
+func stringcmp(attribute string, values []string) bool {
+	for _, value := range values {
+		if strings.EqualFold(value, attribute) {
+			return true
+		}
+	}
+	return false
+}
+
+// float64cmp compares the attribute with each element in values
+// It will cast the elements in the values slice to float64.
+// if any one of values matches it returns true, otherwise false.
+func float64cmp(attribute float64, values []string) bool {
+	for _, value := range values {
+		numberValue, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			log.Warnf("input contains invalid value for number comparisons: %s\n", value)
+			continue
+		}
+		if numberValue == attribute {
+			return true
+		}
+	}
+	return false
+}
+
+// boolcmp compares the attribute with each element in values
+// It will cast the elements in the values slice to bool.
+// if any one of values matches it returns true, otherwise false.
+func boolcmp(attribute bool, values []string) bool {
+	for _, value := range values {
+		boolValue, err := strconv.ParseBool(value)
+		if err != nil {
+			log.Warnf("input contains invalid value for bool comparisons: %s\n", value)
+			continue
+		}
+		if boolValue == attribute {
+			return true
+		}
+	}
+	return false
+}

--- a/types/slice_test.go
+++ b/types/slice_test.go
@@ -19,6 +19,8 @@ func TestSlice_In(t *testing.T) {
 		{"test string interface{} comparison returns true for match", []interface{}{"alpha", "bravo", "charlie"}, []string{"one", "charlie", "three"}, true},
 		{"test string interface{} comparison returns false for no match", []interface{}{"alpha", "bravo", "charlie"}, []string{"one", "two", "three"}, false},
 		{"test string comparison ignores case", []string{"alpha", "bravo", "charlie"}, []string{"one", "BRAVO", "three"}, true},
+		{"test ptr to interface is handled", &[]interface{}{"alpha", "bravo", "charlie"}, []string{"one", "BRAVO", "three"}, true},
+		{"test nil returns false", nil, []string{"one", "BRAVO", "three"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/types/slice_test.go
+++ b/types/slice_test.go
@@ -1,0 +1,33 @@
+package types
+
+import "testing"
+
+func TestSlice_In(t *testing.T) {
+
+	tests := []struct {
+		name   string
+		fields interface{}
+		args   []string
+		want   bool
+	}{
+		{"test string comparison returns true for match", []string{"alpha", "bravo", "charlie"}, []string{"one", "charlie", "three"}, true},
+		{"test string comparison returns false for no match", []string{"alpha", "bravo", "charlie"}, []string{"one", "two", "three"}, false},
+		{"test float64 comparison returns true for match", []float64{10, 40, 60}, []string{"20", "50", "40"}, true},
+		{"test float64 comparison returns false for no match", []float64{10, 40, 60}, []string{"20", "50", "70"}, false},
+		{"test bool comparison returns true for match", []bool{true}, []string{"true"}, true},
+		{"test bool comparison returns false for no match", []bool{true}, []string{"false"}, false},
+		{"test string interface{} comparison returns true for match", []interface{}{"alpha", "bravo", "charlie"}, []string{"one", "charlie", "three"}, true},
+		{"test string interface{} comparison returns false for no match", []interface{}{"alpha", "bravo", "charlie"}, []string{"one", "two", "three"}, false},
+		{"test string comparison ignores case", []string{"alpha", "bravo", "charlie"}, []string{"one", "BRAVO", "three"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Slice{
+				data: tt.fields,
+			}
+			if got := s.In(tt.args); got != tt.want {
+				t.Errorf("In() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/types/string.go
+++ b/types/string.go
@@ -24,31 +24,32 @@ func (s String) String() string {
 	return string(s)
 }
 
-func (s String) operator(value interface{}, fn func(string) bool) bool {
-	slice, ok := value.([]string)
-	if ok {
-		return fn(slice[0]) // need confirmation
+// stringOperator takes the first element from the slice and passes to fn for processing.
+// we ignore any additional elements if they exist.
+func stringOperator(value []string, fn func(string) bool) bool {
+	if len(value) > 0 {
+		return fn(value[0])
 	}
 	return false
 }
 
 // StartsWith check if the string starts with the value
-func (s String) StartsWith(value interface{}) bool {
-	return s.operator(value, func(c string) bool {
+func (s String) StartsWith(value []string) bool {
+	return stringOperator(value, func(c string) bool {
 		return strings.HasPrefix(string(s), c)
 	})
 }
 
 // EndsWith check if the string ends with the value
-func (s String) EndsWith(value interface{}) bool {
-	return s.operator(value, func(c string) bool {
+func (s String) EndsWith(value []string) bool {
+	return stringOperator(value, func(c string) bool {
 		return strings.HasSuffix(string(s), c)
 	})
 }
 
 // Match check if the string match the regex value
-func (s String) Match(value interface{}) bool {
-	return s.operator(value, func(c string) bool {
+func (s String) Match(value []string) bool {
+	return stringOperator(value, func(c string) bool {
 		if matched, err := regexp.MatchString(string(s), c); err == nil {
 			return matched
 		}
@@ -57,62 +58,59 @@ func (s String) Match(value interface{}) bool {
 }
 
 // Contains check if the string contains the value
-func (s String) Contains(value interface{}) bool {
-	return s.operator(value, func(c string) bool {
+func (s String) Contains(value []string) bool {
+	return stringOperator(value, func(c string) bool {
 		return strings.Contains(string(s), c)
 	})
 }
 
 // EqualSensitive check if the string and value are equal (case sensitive)
-func (s String) EqualSensitive(value interface{}) bool {
-	return s.operator(value, func(c string) bool {
+func (s String) EqualSensitive(value []string) bool {
+	return stringOperator(value, func(c string) bool {
 		return string(s) == c
 	})
 }
 
 // Equal check if the string and value are equal
-func (s String) Equal(value interface{}) bool {
-	return s.operator(value, func(c string) bool {
+func (s String) Equal(value []string) bool {
+	return stringOperator(value, func(c string) bool {
 		return strings.EqualFold(string(s), c)
 	})
 }
 
 // GreaterThan checks if the string is greater than the value
-func (s String) GreaterThan(value interface{}) bool {
-	return s.operator(value, func(c string) bool {
+func (s String) GreaterThan(value []string) bool {
+	return stringOperator(value, func(c string) bool {
 		return strings.ToLower(string(s)) > strings.ToLower(c)
 	})
 }
 
 // GreaterThanEqual checks if the string is greater or equal than the value
-func (s String) GreaterThanEqual(value interface{}) bool {
-	return s.operator(value, func(c string) bool {
+func (s String) GreaterThanEqual(value []string) bool {
+	return stringOperator(value, func(c string) bool {
 		return strings.ToLower(string(s)) >= strings.ToLower(c)
 	})
 }
 
 // LessThan checks if the string is less than the value
-func (s String) LessThan(value interface{}) bool {
-	return s.operator(value, func(c string) bool {
+func (s String) LessThan(value []string) bool {
+	return stringOperator(value, func(c string) bool {
 		return strings.ToLower(string(s)) < strings.ToLower(c)
 	})
 }
 
 // LessThanEqual checks if the string is less or equal than the value
-func (s String) LessThanEqual(value interface{}) bool {
-	return s.operator(value, func(c string) bool {
+func (s String) LessThanEqual(value []string) bool {
+	return stringOperator(value, func(c string) bool {
 		return strings.ToLower(string(s)) <= strings.ToLower(c)
 	})
 }
 
 // In checks if the string exist in slice of strings (value)
-func (s String) In(value interface{}) bool {
-	array, ok := value.([]string)
-	if ok {
-		for _, val := range array {
-			if s.Equal(val) {
-				return true
-			}
+func (s String) In(value []string) bool {
+	for _, x := range value {
+		if strings.EqualFold(string(s), x) {
+			return true
 		}
 	}
 	return false

--- a/types/value.go
+++ b/types/value.go
@@ -2,15 +2,15 @@ package types
 
 // ValueType interface used for different clause types
 type ValueType interface {
-	StartsWith(value interface{}) bool
-	EndsWith(value interface{}) bool
-	Match(value interface{}) bool
-	Contains(value interface{}) bool
-	EqualSensitive(value interface{}) bool
-	Equal(value interface{}) bool
-	GreaterThan(value interface{}) bool
-	GreaterThanEqual(value interface{}) bool
-	LessThan(value interface{}) bool
-	LessThanEqual(value interface{}) bool
-	In(value interface{}) bool
+	StartsWith(value []string) bool
+	EndsWith(value []string) bool
+	Match(value []string) bool
+	Contains(value []string) bool
+	EqualSensitive(value []string) bool
+	Equal(value []string) bool
+	GreaterThan(value []string) bool
+	GreaterThanEqual(value []string) bool
+	LessThan(value []string) bool
+	LessThanEqual(value []string) bool
+	In(value []string) bool
 }


### PR DESCRIPTION
This change fixes the bool, int and number comparisons.  It replaces
a cast with the appropriate function from the strconv package.

The slice type is implemented with support for in, contains and equals
operators.

Customers can store target attributes as strings, float64, bool and slices.
When creating a rule the value is always a slice of strings.

The code was trying to cast a string to a int, float etc which does not work.
This caused rules evaluations to fail.

Added unit tests to verify the type operators now work as expected.