### PR TITLE
(maint) Fix gosec issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ lint: $(GOPATH)/bin/golangci-lint $(GOPATH)/bin/golint
 PHONY+= sec
 sec: $(GOPATH)/bin/gosec
 	@echo "Checking for security problems ..."
-	@gosec -quiet ./...
+	@gosec -quiet -confidence high -severity medium ./...
 	@echo "No problems found"; \
 
 $(GOPATH)/bin/golangci-lint:

--- a/storage/file.go
+++ b/storage/file.go
@@ -49,8 +49,10 @@ func (ds *FileStore) Load() error {
 		return err
 	}
 	defer func() {
-		if err := file.Close(); err != nil {
-			ds.logger.Errorf("error closing file, err: %v", err)
+		if file != nil {
+			if err := file.Close(); err != nil {
+				ds.logger.Errorf("error closing file, err: %v", err)
+			}
 		}
 	}()
 	dec := json.NewDecoder(file)
@@ -67,8 +69,10 @@ func (ds *FileStore) Persist() error {
 		return err
 	}
 	defer func() {
-		if err := file.Close(); err != nil {
-			ds.logger.Errorf("error closing file, err: %v", err)
+		if file != nil {
+			if err := file.Close(); err != nil {
+				ds.logger.Errorf("error closing file, err: %v", err)
+			}
 		}
 	}()
 	enc := json.NewEncoder(file)


### PR DESCRIPTION
Added a check that the file is not nil before calling close

This was identified by gosec as an unsafe call to Close()